### PR TITLE
SLING-11779 Add implementation for addMixin method

### DIFF
--- a/src/main/java/org/apache/sling/testing/mock/jcr/MockNode.java
+++ b/src/main/java/org/apache/sling/testing/mock/jcr/MockNode.java
@@ -372,26 +372,30 @@ class MockNode extends AbstractItem implements Node {
 
     @Override
     public NodeType[] getMixinNodeTypes() throws RepositoryException {
-        Value[] mixinNames = getProperty(JcrConstants.JCR_MIXINTYPES).getValues();
-
-        return Arrays.stream(mixinNames)
-                .map(value -> {
-                    try {
-                        return value.getString();
-                    } catch (RepositoryException e) {
-                        return new NodeType[0];
-                    }
-                })
-                .filter(Objects::nonNull)
-                .map(name -> {
-                    try {
-                        return getSession().getWorkspace().getNodeTypeManager().getNodeType(name.toString());
-                    } catch (RepositoryException e) {
-                        return new NodeType[0];
-                    }
-                })
-                .filter(Objects::nonNull)
-                .toArray(NodeType[]::new);
+        try{
+            Value[] mixinNames = getProperty(JcrConstants.JCR_MIXINTYPES).getValues();
+            return Arrays.stream(mixinNames)
+                    .map(value -> {
+                        try {
+                            return value.getString();
+                        } catch (RepositoryException e) {
+                            return new NodeType[0];
+                        }
+                    })
+                    .filter(Objects::nonNull)
+                    .map(name -> {
+                        try {
+                            return getSession().getWorkspace().getNodeTypeManager().getNodeType(name.toString());
+                        } catch (RepositoryException e) {
+                            return new NodeType[0];
+                        }
+                    })
+                    .filter(Objects::nonNull)
+                    .toArray(NodeType[]::new);
+        } catch(PathNotFoundException e) {
+            // if there are not already mixin types added, return new array
+            return new NodeType[0];
+        }
     }
 
     @Override

--- a/src/main/java/org/apache/sling/testing/mock/jcr/MockNode.java
+++ b/src/main/java/org/apache/sling/testing/mock/jcr/MockNode.java
@@ -22,8 +22,6 @@ import java.io.InputStream;
 import java.math.BigDecimal;
 import java.util.Arrays;
 import java.util.Calendar;
-import java.util.Iterator;
-import java.util.List;
 import java.util.regex.Pattern;
 
 import javax.jcr.Binary;
@@ -48,7 +46,6 @@ import org.apache.jackrabbit.commons.ItemNameMatcher;
 import org.apache.jackrabbit.commons.iterator.NodeIteratorAdapter;
 import org.apache.jackrabbit.commons.iterator.PropertyIteratorAdapter;
 
-import static javax.swing.text.html.parser.DTDConstants.NAMES;
 
 /**
  * Mock {@link Node} implementation

--- a/src/main/java/org/apache/sling/testing/mock/jcr/MockNode.java
+++ b/src/main/java/org/apache/sling/testing/mock/jcr/MockNode.java
@@ -410,10 +410,11 @@ class MockNode extends AbstractItem implements Node {
                 String[] mixinNames = new String[]{mixinName};
                 setProperty(JcrConstants.JCR_MIXINTYPES, mixinNames);
             } else {
-                Value[] currentValues = getProperty(JcrConstants.JCR_MIXINTYPES).getValues();
                 Value value = this.getSession().getValueFactory().createValue(mixinName);
-                Value[] newValues = Arrays.copyOf(currentValues, currentValues.length + 1);
-                newValues[newValues.length - 1] = value;
+                Value[] newValues = Stream.concat(
+                        Arrays.stream(getProperty(JcrConstants.JCR_MIXINTYPES).getValues()),
+                        Stream.of(value)
+                ).toArray(Value[]::new);
                 this.setProperty(JcrConstants.JCR_MIXINTYPES, newValues);
             }
         } else {
@@ -426,14 +427,10 @@ class MockNode extends AbstractItem implements Node {
         if (this.hasProperty(JcrConstants.JCR_MIXINTYPES)) {
             Value[] currentValues = getProperty(JcrConstants.JCR_MIXINTYPES).getValues();
             Value valueToBeRemoved = this.getSession().getValueFactory().createValue(mixinName);
-            Value[] newValues = new Value[currentValues.length - 1];
-            for (int i = 0, j = 0; i < currentValues.length; i++) {
-                if (!currentValues[i].equals(valueToBeRemoved)) {
-                    newValues[j] = currentValues[i];
-                    j++;
-                }
-                this.setProperty(JcrConstants.JCR_MIXINTYPES, newValues);
-            }
+            Value[] newValues = Arrays.stream(currentValues)
+                    .filter(value -> !value.equals(valueToBeRemoved))
+                    .toArray(Value[]::new);
+            this.setProperty(JcrConstants.JCR_MIXINTYPES, newValues);
         }
     }
     

--- a/src/main/java/org/apache/sling/testing/mock/jcr/MockNode.java
+++ b/src/main/java/org/apache/sling/testing/mock/jcr/MockNode.java
@@ -436,6 +436,11 @@ class MockNode extends AbstractItem implements Node {
             }
         }
     }
+    
+        @Override
+    public boolean canAddMixin(final String mixinName) throws RepositoryException {
+       return true;
+    }
 
     // --- unsupported operations ---
     @Override
@@ -455,11 +460,6 @@ class MockNode extends AbstractItem implements Node {
 
     @Override
     public Property setProperty(final String name, final String value, final int type) throws RepositoryException {
-        throw new UnsupportedOperationException();
-    }
-
-    @Override
-    public boolean canAddMixin(final String mixinName) throws RepositoryException {
         throw new UnsupportedOperationException();
     }
 

--- a/src/main/java/org/apache/sling/testing/mock/jcr/MockNode.java
+++ b/src/main/java/org/apache/sling/testing/mock/jcr/MockNode.java
@@ -394,6 +394,17 @@ class MockNode extends AbstractItem implements Node {
             throw new NoSuchNodeTypeException("Not accepting blank node types");
         }
     }
+    
+    @Override
+    public void addMixin(final String mixinName) throws RepositoryException {
+        if (StringUtils.isNotBlank(mixinName)) {
+            if(!this.hasProperty(JcrConstants.JCR_MIXINTYPES)) {
+                setProperty(JcrConstants.JCR_MIXINTYPES, mixinName);
+            }
+        } else {
+            throw new NoSuchNodeTypeException("Not accepting blank mixin name");
+        }
+    }
 
     // --- unsupported operations ---
     @Override
@@ -413,11 +424,6 @@ class MockNode extends AbstractItem implements Node {
 
     @Override
     public Property setProperty(final String name, final String value, final int type) throws RepositoryException {
-        throw new UnsupportedOperationException();
-    }
-
-    @Override
-    public void addMixin(final String mixinName) throws RepositoryException {
         throw new UnsupportedOperationException();
     }
 

--- a/src/main/java/org/apache/sling/testing/mock/jcr/MockNode.java
+++ b/src/main/java/org/apache/sling/testing/mock/jcr/MockNode.java
@@ -420,7 +420,7 @@ class MockNode extends AbstractItem implements Node {
             Value valueToBeRemoved = this.getSession().getValueFactory().createValue(mixinName);
             Value[] newValues = new Value[currentValues.length - 1];
             for (int i = 0, j = 0; i < currentValues.length; i++) {
-                if (currentValues[i].equals(valueToBeRemoved)) {
+                if (!currentValues[i].equals(valueToBeRemoved)) {
                     newValues[j] = currentValues[i];
                     j++;
                 }

--- a/src/main/java/org/apache/sling/testing/mock/jcr/MockNode.java
+++ b/src/main/java/org/apache/sling/testing/mock/jcr/MockNode.java
@@ -373,9 +373,6 @@ class MockNode extends AbstractItem implements Node {
     @Override
     public NodeType[] getMixinNodeTypes() throws RepositoryException {
         Value[] mixinNames = getProperty(JcrConstants.JCR_MIXINTYPES).getValues();
-        if (mixinNames == null) {
-            return new NodeType[0];
-        }
 
         return Arrays.stream(mixinNames)
                 .map(value -> {
@@ -448,12 +445,9 @@ class MockNode extends AbstractItem implements Node {
                     .filter(value -> !value.equals(valueToBeRemoved))
                     .toArray(Value[]::new);
             this.setProperty(JcrConstants.JCR_MIXINTYPES, newValues);
+        } else {
+            throw new NoSuchNodeTypeException("Cannot remove blank mixin");
         }
-    }
-    
-        @Override
-    public boolean canAddMixin(final String mixinName) throws RepositoryException {
-       return true;
     }
 
     // --- unsupported operations ---
@@ -474,6 +468,11 @@ class MockNode extends AbstractItem implements Node {
 
     @Override
     public Property setProperty(final String name, final String value, final int type) throws RepositoryException {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public boolean canAddMixin(final String mixinName) throws RepositoryException {
         throw new UnsupportedOperationException();
     }
 

--- a/src/main/java/org/apache/sling/testing/mock/jcr/MockNode.java
+++ b/src/main/java/org/apache/sling/testing/mock/jcr/MockNode.java
@@ -31,6 +31,7 @@ import javax.jcr.Item;
 import javax.jcr.ItemNotFoundException;
 import javax.jcr.Node;
 import javax.jcr.NodeIterator;
+import javax.jcr.PathNotFoundException;
 import javax.jcr.Property;
 import javax.jcr.PropertyIterator;
 import javax.jcr.RangeIterator;

--- a/src/main/java/org/apache/sling/testing/mock/jcr/MockNode.java
+++ b/src/main/java/org/apache/sling/testing/mock/jcr/MockNode.java
@@ -368,8 +368,16 @@ class MockNode extends AbstractItem implements Node {
 
     @Override
     public NodeType[] getMixinNodeTypes() throws RepositoryException {
-        // we have no real mixin support - just assume no mixin nodetypes are set
-        return new NodeType[0];
+       Value[] mixinNames = getProperty(JcrConstants.JCR_MIXINTYPES).getValues();
+        if (mixinNames == null) {
+            return new NodeType[0];
+        }
+
+        NodeType[] nodeTypes = new NodeType[mixinNames.length];
+        for(int i = 0; i < mixinNames.length; i++) {
+            nodeTypes[i] = getSession().getWorkspace().getNodeTypeManager().getNodeType(mixinNames[i].getString());
+        }
+        return nodeTypes;
     }
 
     @Override

--- a/src/main/java/org/apache/sling/testing/mock/jcr/MockNode.java
+++ b/src/main/java/org/apache/sling/testing/mock/jcr/MockNode.java
@@ -379,7 +379,7 @@ class MockNode extends AbstractItem implements Node {
                         try {
                             return value.getString();
                         } catch (RepositoryException e) {
-                            return new NodeType[0];
+                            return null;
                         }
                     })
                     .filter(Objects::nonNull)
@@ -387,13 +387,13 @@ class MockNode extends AbstractItem implements Node {
                         try {
                             return getSession().getWorkspace().getNodeTypeManager().getNodeType(name.toString());
                         } catch (RepositoryException e) {
-                            return new NodeType[0];
+                            return null;
                         }
                     })
                     .filter(Objects::nonNull)
                     .toArray(NodeType[]::new);
         } catch(PathNotFoundException e) {
-            // if there are not already mixin types added, return new array
+            // if there are not already mixin types added, return empty array
             return new NodeType[0];
         }
     }

--- a/src/main/java/org/apache/sling/testing/mock/jcr/MockNode.java
+++ b/src/main/java/org/apache/sling/testing/mock/jcr/MockNode.java
@@ -386,7 +386,7 @@ class MockNode extends AbstractItem implements Node {
                     .filter(Objects::nonNull)
                     .map(name -> {
                         try {
-                            return getSession().getWorkspace().getNodeTypeManager().getNodeType(name.toString());
+                            return getSession().getWorkspace().getNodeTypeManager().getNodeType(name);
                         } catch (RepositoryException e) {
                             return null;
                         }
@@ -421,7 +421,7 @@ class MockNode extends AbstractItem implements Node {
             throw new NoSuchNodeTypeException("Not accepting blank node types");
         }
     }
-    
+
     @Override
     public void addMixin(final String mixinName) throws RepositoryException {
         if (StringUtils.isNotBlank(mixinName)) {

--- a/src/main/java/org/apache/sling/testing/mock/jcr/MockNodeType.java
+++ b/src/main/java/org/apache/sling/testing/mock/jcr/MockNodeType.java
@@ -54,6 +54,12 @@ class MockNodeType implements NodeType {
         // support only well-known built-in node type
         return StringUtils.equals(getName(), JcrConstants.NT_UNSTRUCTURED);
     }
+    
+        @Override
+    public boolean isMixin() {
+        // if it has at least 1 supertype -> isMixin
+       return (getDeclaredSupertypes().length > 0);
+    }
 
 
     // --- unsupported operations ---
@@ -114,11 +120,6 @@ class MockNodeType implements NodeType {
 
     @Override
     public NodeType[] getSupertypes() {
-        throw new UnsupportedOperationException();
-    }
-
-    @Override
-    public boolean isMixin() {
         throw new UnsupportedOperationException();
     }
 

--- a/src/main/java/org/apache/sling/testing/mock/jcr/MockNodeType.java
+++ b/src/main/java/org/apache/sling/testing/mock/jcr/MockNodeType.java
@@ -54,12 +54,6 @@ class MockNodeType implements NodeType {
         // support only well-known built-in node type
         return StringUtils.equals(getName(), JcrConstants.NT_UNSTRUCTURED);
     }
-    
-        @Override
-    public boolean isMixin() {
-        // if it has at least 1 supertype -> isMixin
-       return (getDeclaredSupertypes().length > 0);
-    }
 
 
     // --- unsupported operations ---
@@ -120,6 +114,11 @@ class MockNodeType implements NodeType {
 
     @Override
     public NodeType[] getSupertypes() {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public boolean isMixin() {
         throw new UnsupportedOperationException();
     }
 

--- a/src/test/java/org/apache/sling/testing/mock/jcr/MockNodeTest.java
+++ b/src/test/java/org/apache/sling/testing/mock/jcr/MockNodeTest.java
@@ -284,12 +284,4 @@ public class MockNodeTest {
         node1.removeMixin("mix:taggable");
         assertEquals(1 , node1.getProperty(JcrConstants.JCR_MIXINTYPES).getValues().length);
     }
-
-    @Test
-    public void getMixinNodeTypesTest() throws RepositoryException {
-        node1.addMixin("mix:taggable");
-        node1.addMixin("mix:mixin");
-        NodeType[] nodeTypes = node1.getMixinNodeTypes();
-        //assertEquals(, nodeTypes);
-    }
 }

--- a/src/test/java/org/apache/sling/testing/mock/jcr/MockNodeTest.java
+++ b/src/test/java/org/apache/sling/testing/mock/jcr/MockNodeTest.java
@@ -186,8 +186,8 @@ public class MockNodeTest {
         assertEquals("mix:taggable" ,node1.getMixinNodeTypes()[1].getName());
     }
     @Test
-    public void testGetMixinNodeNoMixinTypes() throws Exception {
-        assertThrows(PathNotFoundException.class, () -> node1.getMixinNodeTypes());
+    public void testGetMixinNodeNoMixinTypes() throws RepositoryException {
+        assertEquals(0, node1.getMixinNodeTypes().length);
     }
 
     @Test

--- a/src/test/java/org/apache/sling/testing/mock/jcr/MockNodeTest.java
+++ b/src/test/java/org/apache/sling/testing/mock/jcr/MockNodeTest.java
@@ -191,7 +191,10 @@ public class MockNodeTest {
 
     @Test
     public void testGetMixinNodeTypes() throws Exception {
-        assertEquals(0, this.node1.getMixinNodeTypes().length);
+        node1.addMixin("mix:referenceable");
+        node1.addMixin("mix:taggable");
+        assertEquals(2, node1.getMixinNodeTypes().length);
+        assertEquals("mix:taggable" ,node1.getMixinNodeTypes()[1].getName());
     }
 
     @Test

--- a/src/test/java/org/apache/sling/testing/mock/jcr/MockNodeTest.java
+++ b/src/test/java/org/apache/sling/testing/mock/jcr/MockNodeTest.java
@@ -261,5 +261,12 @@ public class MockNodeTest {
         });
         return names.toArray(new String[names.size()]);
     }
+    
+    @Test
+    public void addMixinTest() throws RepositoryException {
+        Node node = this.rootNode.addNode("node");
+        node.addMixin("mix:referenceable");
+        assertEquals("mix:referenceable", node.getProperty(JcrConstants.JCR_MIXINTYPES).getValue().getString());
+    }
 
 }

--- a/src/test/java/org/apache/sling/testing/mock/jcr/MockNodeTest.java
+++ b/src/test/java/org/apache/sling/testing/mock/jcr/MockNodeTest.java
@@ -38,6 +38,7 @@ import javax.jcr.PropertyIterator;
 import javax.jcr.RepositoryException;
 import javax.jcr.Session;
 import javax.jcr.nodetype.NoSuchNodeTypeException;
+import javax.jcr.nodetype.NodeType;
 
 import org.apache.jackrabbit.JcrConstants;
 import org.junit.Assert;
@@ -264,9 +265,31 @@ public class MockNodeTest {
     
     @Test
     public void addMixinTest() throws RepositoryException {
-        Node node = this.rootNode.addNode("node");
-        node.addMixin("mix:referenceable");
-        assertEquals("mix:referenceable", node.getProperty(JcrConstants.JCR_MIXINTYPES).getValue().getString());
+        node1.addMixin("mix:referenceable");
+        assertEquals("mix:referenceable", node1.getProperty(JcrConstants.JCR_MIXINTYPES).getValue().getString());
     }
 
+    @Test
+    public void addMixinsTest() throws RepositoryException {
+        node1.addMixin("mix:referenceable");
+        node1.addMixin("mix:taggable");
+        node1.addMixin("mix:mixin");
+        assertEquals(3, node1.getProperty(JcrConstants.JCR_MIXINTYPES).getValues().length);
+    }
+
+    @Test
+    public void removeMixinTest() throws RepositoryException {
+        node1.addMixin("mix:taggable");
+        node1.addMixin("mix:mixin");
+        node1.removeMixin("mix:taggable");
+        assertEquals(1 , node1.getProperty(JcrConstants.JCR_MIXINTYPES).getValues().length);
+    }
+
+    @Test
+    public void getMixinNodeTypesTest() throws RepositoryException {
+        node1.addMixin("mix:taggable");
+        node1.addMixin("mix:mixin");
+        NodeType[] nodeTypes = node1.getMixinNodeTypes();
+        //assertEquals(, nodeTypes);
+    }
 }

--- a/src/test/java/org/apache/sling/testing/mock/jcr/MockNodeTest.java
+++ b/src/test/java/org/apache/sling/testing/mock/jcr/MockNodeTest.java
@@ -25,7 +25,6 @@ import java.util.Map;
 
 import javax.jcr.*;
 import javax.jcr.nodetype.NoSuchNodeTypeException;
-import javax.jcr.nodetype.NodeType;
 
 import org.apache.jackrabbit.JcrConstants;
 import org.junit.Assert;

--- a/src/test/java/org/apache/sling/testing/mock/jcr/MockNodeTest.java
+++ b/src/test/java/org/apache/sling/testing/mock/jcr/MockNodeTest.java
@@ -18,25 +18,12 @@
  */
 package org.apache.sling.testing.mock.jcr;
 
-import static org.junit.Assert.assertArrayEquals;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertTrue;
-import static org.junit.Assert.fail;
-
 import java.util.HashMap;
 import java.util.LinkedList;
 import java.util.List;
 import java.util.Map;
 
-import javax.jcr.ItemNotFoundException;
-import javax.jcr.Node;
-import javax.jcr.NodeIterator;
-import javax.jcr.Property;
-import javax.jcr.PropertyIterator;
-import javax.jcr.RepositoryException;
-import javax.jcr.Session;
+import javax.jcr.*;
 import javax.jcr.nodetype.NoSuchNodeTypeException;
 import javax.jcr.nodetype.NodeType;
 
@@ -44,6 +31,8 @@ import org.apache.jackrabbit.JcrConstants;
 import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
+
+import static org.junit.Assert.*;
 
 public class MockNodeTest {
 
@@ -196,6 +185,10 @@ public class MockNodeTest {
         assertEquals(2, node1.getMixinNodeTypes().length);
         assertEquals("mix:taggable" ,node1.getMixinNodeTypes()[1].getName());
     }
+    @Test
+    public void testGetMixinNodeNoMixinTypes() throws Exception {
+        assertThrows(PathNotFoundException.class, () -> node1.getMixinNodeTypes());
+    }
 
     @Test
     public void testIsModified() throws RepositoryException {
@@ -273,6 +266,11 @@ public class MockNodeTest {
     }
 
     @Test
+    public void addBlankMixinTest() throws RepositoryException {
+        assertThrows(NoSuchNodeTypeException.class, () -> node1.addMixin(""));
+    }
+
+    @Test
     public void addMixinsTest() throws RepositoryException {
         node1.addMixin("mix:referenceable");
         node1.addMixin("mix:taggable");
@@ -287,5 +285,10 @@ public class MockNodeTest {
         node1.removeMixin("mix:taggable");
         assertEquals(1 , node1.getProperty(JcrConstants.JCR_MIXINTYPES).getValues().length);
         assertEquals("mix:mixin" , node1.getProperty(JcrConstants.JCR_MIXINTYPES).getValues()[0].getString());
+    }
+
+    @Test
+    public void removeBlankMixin() {
+        assertThrows(NoSuchNodeTypeException.class, () -> node1.removeMixin(""));
     }
 }

--- a/src/test/java/org/apache/sling/testing/mock/jcr/MockNodeTest.java
+++ b/src/test/java/org/apache/sling/testing/mock/jcr/MockNodeTest.java
@@ -283,5 +283,6 @@ public class MockNodeTest {
         node1.addMixin("mix:mixin");
         node1.removeMixin("mix:taggable");
         assertEquals(1 , node1.getProperty(JcrConstants.JCR_MIXINTYPES).getValues().length);
+        assertEquals("mix:mixin" , node1.getProperty(JcrConstants.JCR_MIXINTYPES).getValues()[0].getString());
     }
 }

--- a/src/test/java/org/apache/sling/testing/mock/jcr/MockNodeTest.java
+++ b/src/test/java/org/apache/sling/testing/mock/jcr/MockNodeTest.java
@@ -266,7 +266,7 @@ public class MockNodeTest {
     @Test
     public void addMixinTest() throws RepositoryException {
         node1.addMixin("mix:referenceable");
-        assertEquals("mix:referenceable", node1.getProperty(JcrConstants.JCR_MIXINTYPES).getValue().getString());
+        assertEquals("mix:referenceable", node1.getProperty(JcrConstants.JCR_MIXINTYPES).getValues()[0].getString());
     }
 
     @Test


### PR DESCRIPTION
Add implementation for method `addMixin()` according to developer documentation:

> Adds the mixin node type named mixinName to this node. If this node is already of type mixinName (either due to a previously added mixin or due to its primary type, through inheritance) then this method has no effect. Otherwise mixinName is added to this node's jcr:mixinTypes property.