### PR TITLE
SLING-11786 MockNode#isNodeType should also check the mixin types

### DIFF
--- a/src/main/java/org/apache/sling/testing/mock/jcr/MockNode.java
+++ b/src/main/java/org/apache/sling/testing/mock/jcr/MockNode.java
@@ -338,7 +338,12 @@ class MockNode extends AbstractItem implements Node {
 
     @Override
     public boolean isNodeType(final String nodeTypeName) throws RepositoryException {
-        return this.itemData.getNodeType().isNodeType(nodeTypeName);
+        boolean istype = this.itemData.getNodeType().isNodeType(nodeTypeName);
+        if (!istype) {
+            // SLING-11786 also check the mixin types
+            istype = Arrays.stream(getMixinNodeTypes()).anyMatch(nt -> nt.getName().equals(nodeTypeName));
+        }
+        return istype;
     }
 
     @Override

--- a/src/test/java/org/apache/sling/testing/mock/jcr/MockNodeTest.java
+++ b/src/test/java/org/apache/sling/testing/mock/jcr/MockNodeTest.java
@@ -290,4 +290,20 @@ public class MockNodeTest {
     public void removeBlankMixin() {
         assertThrows(NoSuchNodeTypeException.class, () -> node1.removeMixin(""));
     }
+
+    /**
+     * Test SLING-11786
+     */
+    @Test
+    public void isNodeTypeTest() throws RepositoryException {
+        // check primary type
+        assertTrue(node1.isNodeType(node1.getPrimaryNodeType().getName()));
+
+        // check mixin type that is not set
+        assertFalse(node1.isNodeType("mix:referenceable"));
+
+        // check setting mixin type and check again
+        node1.addMixin("mix:referenceable");
+        assertTrue(node1.isNodeType("mix:referenceable"));
+    }
 }


### PR DESCRIPTION
After mixin types are added to the MockNode object, then calls to MockNode#isNodeType(mixinType) for that mixin type should return true.