### PR TITLE
SLING-11789 MockNode#orderBefore incorrectly removes nodes

### DIFF
--- a/src/main/java/org/apache/sling/testing/mock/jcr/MockSession.java
+++ b/src/main/java/org/apache/sling/testing/mock/jcr/MockSession.java
@@ -226,9 +226,11 @@ class MockSession implements Session {
         }
 
         // Find all items matching the source
+        final String sourcePath = source.getPath();
+        final String sourcePathPrefix = String.format("%s/", sourcePath);
         List<ItemData> itemsToMove = new LinkedList<>();
         for (String key : new ArrayList<>(items.keySet())) {
-            if (key.startsWith(source.getPath())) {
+            if (key.equals(sourcePath) || key.startsWith(sourcePathPrefix)) {
                 itemsToMove.add(items.remove(key));
             }
         }

--- a/src/test/java/org/apache/sling/testing/mock/jcr/MockNodeTest.java
+++ b/src/test/java/org/apache/sling/testing/mock/jcr/MockNodeTest.java
@@ -226,6 +226,33 @@ public class MockNodeTest {
                 getNodeNames(foo.getNodes()));
     }
 
+    /**
+     * SLING-11789 Verify that orderBefore works when the names of the child nodes
+     * have a common prefix.
+     */
+    @Test
+    public void testOrderBeforeWithCommonPrefix() throws RepositoryException {
+        Node foo = this.session.getRootNode().addNode("foo");
+        this.session.save();
+        foo.addNode("child100");
+        foo.addNode("child10");
+        foo.addNode("child1");
+        session.save();
+        assertArrayEquals("Expected nodes order mismatch",
+                new String[] {"child100", "child10", "child1"},
+                getNodeNames(foo.getNodes()));
+        foo.orderBefore("child10", "child100");
+        session.save();
+        assertArrayEquals("Expected nodes order mismatch",
+                new String[] {"child10", "child100", "child1"},
+                getNodeNames(foo.getNodes()));
+        foo.orderBefore("child10", null);
+        session.save();
+        assertArrayEquals("Expected nodes order mismatch",
+                new String[] {"child100", "child1", "child10"},
+                getNodeNames(foo.getNodes()));
+    }
+
     @Test
     public void testNodeDefinition() throws RepositoryException {
         Node node1 = this.session.getRootNode().getNode("node1");


### PR DESCRIPTION
The MockNode#orderBefore implementation is using a simple "startsWith" check on path strings to find the items to move.  This will match too many items if the sibling nodes have names with a common prefix.

For example, for the following scenario child10 should be ordered before child100, but what actually happens is both child10 and child100 get removed from the parent.

Node foo = this.session.getRootNode().addNode("foo");
foo.addNode("child100");
foo.addNode("child10");
foo.addNode("child1");
foo.orderBefore("child10", "child100"); 

Expected:
The "find all items matching the source" logic in MockSession#orderBefore should be changed to match paths that equal the source path exactly or starts with the source path with a trailing slash.