### PR TITLE
SLING-11804 Implement item#isSame support for JCR Mock

### DIFF
--- a/src/main/java/org/apache/sling/testing/mock/jcr/AbstractItem.java
+++ b/src/main/java/org/apache/sling/testing/mock/jcr/AbstractItem.java
@@ -119,7 +119,7 @@ abstract class AbstractItem implements Item {
         // Both objects were acquired through Session objects that were created by the same Repository object.
         // Both objects were acquired through Session objects bound to the same repository workspace.
         if (Objects.equals(getSession().getRepository(), otherItem.getSession().getRepository()) &&
-                Objects.equals(getSession().getWorkspace(), otherItem.getSession().getWorkspace())) {
+                Objects.equals(getSession().getWorkspace().getName(), otherItem.getSession().getWorkspace().getName())) {
             // The objects are either both Node objects or both Property objects.
             if (isNode() && otherItem.isNode()) {
                 // they are Node objects, they must have the same identifier.

--- a/src/main/java/org/apache/sling/testing/mock/jcr/AbstractItem.java
+++ b/src/main/java/org/apache/sling/testing/mock/jcr/AbstractItem.java
@@ -18,6 +18,8 @@
  */
 package org.apache.sling.testing.mock.jcr;
 
+import java.util.Objects;
+
 import javax.jcr.Item;
 import javax.jcr.ItemNotFoundException;
 import javax.jcr.ItemVisitor;
@@ -113,7 +115,25 @@ abstract class AbstractItem implements Item {
 
     @Override
     public boolean isSame(final Item otherItem) throws RepositoryException {
-        throw new UnsupportedOperationException();
+        boolean same = false;
+        // Both objects were acquired through Session objects that were created by the same Repository object.
+        // Both objects were acquired through Session objects bound to the same repository workspace.
+        if (Objects.equals(getSession().getRepository(), otherItem.getSession().getRepository()) &&
+                Objects.equals(getSession().getWorkspace(), otherItem.getSession().getWorkspace())) {
+            // The objects are either both Node objects or both Property objects.
+            if (isNode() && otherItem.isNode()) {
+                // they are Node objects, they must have the same identifier.
+                if (Objects.equals(((Node)this).getIdentifier(), ((Node)otherItem).getIdentifier())) {
+                    same = true;
+                }
+            } else if (!isNode() && !otherItem.isNode() &&
+                    // Property objects must have identical names and isSame is true of their parent nodes.
+                    Objects.equals(getName(), otherItem.getName()) &&
+                    getParent().isSame(otherItem.getParent())) {
+                same = true;
+            }
+        }
+        return same;
     }
 
     @Override

--- a/src/test/java/org/apache/sling/testing/mock/jcr/AbstractItemTest.java
+++ b/src/test/java/org/apache/sling/testing/mock/jcr/AbstractItemTest.java
@@ -21,6 +21,7 @@ package org.apache.sling.testing.mock.jcr;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertSame;
+import static org.junit.Assert.assertTrue;
 
 import javax.jcr.ItemNotFoundException;
 import javax.jcr.Node;
@@ -33,11 +34,11 @@ import org.junit.Test;
 
 public abstract class AbstractItemTest {
 
-    private Session session;
-    private Node rootNode;
-    private Node node1;
-    private Property prop1;
-    private Node node11;
+    protected Session session;
+    protected Node rootNode;
+    protected Node node1;
+    protected Property prop1;
+    protected Node node11;
 
     @Before
     public void setUp() throws RepositoryException {
@@ -56,16 +57,16 @@ public abstract class AbstractItemTest {
 
     @Test
     public void testGetParent() throws RepositoryException {
-        assertSame(this.rootNode, this.node1.getParent());
-        assertSame(this.node1, this.prop1.getParent());
-        assertSame(this.node1, this.node11.getParent());
+        assertTrue(this.rootNode.isSame(this.node1.getParent()));
+        assertTrue(this.node1.isSame(this.prop1.getParent()));
+        assertTrue(this.node1.isSame(this.node11.getParent()));
     }
 
     @Test
     public void testGetAncestor() throws RepositoryException {
-        assertSame(this.node11, this.node11.getAncestor(0));
-        assertSame(this.node1, this.node11.getAncestor(1));
-        assertSame(this.rootNode, this.node11.getAncestor(2));
+        assertTrue(this.node11.isSame(this.node11.getAncestor(0)));
+        assertTrue(this.node1.isSame(this.node11.getAncestor(1)));
+        assertTrue(this.rootNode.isSame(this.node11.getAncestor(2)));
     }
 
     @Test(expected = ItemNotFoundException.class)
@@ -86,10 +87,29 @@ public abstract class AbstractItemTest {
     }
 
     @Test
-    public void testModifiedNew() {
-        // methods return always false
+    public void testModifiedNew() throws RepositoryException {
+        // new item is not 'modified' when 'new'
+        assertFalse(this.node1.isModified());
+        assertTrue(this.node1.isNew());
+
+        // save the pending changes
+        this.session.save();
         assertFalse(this.node1.isModified());
         assertFalse(this.node1.isNew());
+
+        // not-new node can now be 'modified' after changes
+        ((MockNode)this.node1).itemData.setIsChanged(true);
+        assertTrue(this.node1.isModified());
+        assertFalse(this.node1.isNew());
+    }
+
+    @Test
+    public void testIsSameForNodeComparedToProp() throws RepositoryException {
+        assertFalse(this.node1.isSame(this.prop1));
+    }
+    @Test
+    public void testIsSameForPropComparedToNode() throws RepositoryException {
+        assertFalse(this.prop1.isSame(this.node1));
     }
 
 }

--- a/src/test/java/org/apache/sling/testing/mock/jcr/MockNodeTest.java
+++ b/src/test/java/org/apache/sling/testing/mock/jcr/MockNodeTest.java
@@ -18,37 +18,32 @@
  */
 package org.apache.sling.testing.mock.jcr;
 
+import static org.junit.Assert.assertArrayEquals;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertThrows;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
+
 import java.util.HashMap;
 import java.util.LinkedList;
 import java.util.List;
 import java.util.Map;
 
-import javax.jcr.*;
+import javax.jcr.ItemNotFoundException;
+import javax.jcr.Node;
+import javax.jcr.NodeIterator;
+import javax.jcr.Property;
+import javax.jcr.PropertyIterator;
+import javax.jcr.RepositoryException;
 import javax.jcr.nodetype.NoSuchNodeTypeException;
 
 import org.apache.jackrabbit.JcrConstants;
 import org.junit.Assert;
-import org.junit.Before;
 import org.junit.Test;
 
-import static org.junit.Assert.*;
-
-public class MockNodeTest {
-
-    private Session session;
-    private Node rootNode;
-    private Node node1;
-    private Property prop1;
-    private Node node11;
-
-    @Before
-    public void setUp() throws RepositoryException {
-        this.session = MockJcr.newSession();
-        this.rootNode = this.session.getRootNode();
-        this.node1 = this.rootNode.addNode("node1");
-        this.prop1 = this.node1.setProperty("prop1", "value1");
-        this.node11 = this.node1.addNode("node11");
-    }
+public class MockNodeTest extends AbstractItemTest {
 
     @Test
     public void testGetNodes() throws RepositoryException {
@@ -333,4 +328,22 @@ public class MockNodeTest {
         node1.addMixin("mix:referenceable");
         assertTrue(node1.isNodeType("mix:referenceable"));
     }
+
+    @Test
+    public void testIsSameForNodeComparedToItself() throws RepositoryException {
+        assertTrue(this.node1.isSame(this.node1));
+    }
+
+    @Test
+    public void testIsSameForNodeComparedToSameNode() throws RepositoryException {
+        // a different object referencing the same node
+        Node node1ref = this.rootNode.getNode("node1");
+        assertTrue(this.node1.isSame(node1ref));
+    }
+
+    @Test
+    public void testIsSameForNodeComparedToDifferentNode() throws RepositoryException {
+        assertFalse(this.node1.isSame(this.node11));
+    }
+
 }

--- a/src/test/java/org/apache/sling/testing/mock/jcr/MockNodeTest.java
+++ b/src/test/java/org/apache/sling/testing/mock/jcr/MockNodeTest.java
@@ -36,7 +36,9 @@ import javax.jcr.Node;
 import javax.jcr.NodeIterator;
 import javax.jcr.Property;
 import javax.jcr.PropertyIterator;
+import javax.jcr.Repository;
 import javax.jcr.RepositoryException;
+import javax.jcr.Session;
 import javax.jcr.nodetype.NoSuchNodeTypeException;
 
 import org.apache.jackrabbit.JcrConstants;
@@ -344,6 +346,23 @@ public class MockNodeTest extends AbstractItemTest {
     @Test
     public void testIsSameForNodeComparedToDifferentNode() throws RepositoryException {
         assertFalse(this.node1.isSame(this.node11));
+    }
+
+    @Test
+    public void testIsSameForNodeFromDifferentRepository() throws RepositoryException {
+        Repository otherRepository = MockJcr.newRepository();
+        Session otherSession = otherRepository.login();
+        Node otherNode1 = otherSession.getRootNode().addNode("node1");
+        assertFalse(this.node1.isSame(otherNode1));
+    }
+
+    @Test
+    public void testIsSameForNodeFromDifferentWorkspace() throws RepositoryException {
+        Session otherSession = session.getRepository().login("otherWorkspace");
+        Node otherRootNode = otherSession.getRootNode();
+        Node otherNode1 = otherRootNode.addNode("node1");
+
+        assertFalse(this.node1.isSame(otherNode1));
     }
 
 }

--- a/src/test/java/org/apache/sling/testing/mock/jcr/MockPropertyTest.java
+++ b/src/test/java/org/apache/sling/testing/mock/jcr/MockPropertyTest.java
@@ -29,31 +29,17 @@ import java.io.InputStream;
 import java.math.BigDecimal;
 import java.util.Calendar;
 
-import javax.jcr.Node;
 import javax.jcr.Property;
 import javax.jcr.PropertyType;
 import javax.jcr.RepositoryException;
-import javax.jcr.Session;
 import javax.jcr.Value;
 import javax.jcr.ValueFormatException;
 
 import org.apache.commons.io.IOUtils;
 import org.apache.jackrabbit.value.BinaryValue;
-import org.junit.Before;
 import org.junit.Test;
 
-public class MockPropertyTest {
-
-    private Session session;
-    private Node rootNode;
-    private Node node1;
-
-    @Before
-    public void setUp() throws RepositoryException {
-        this.session = MockJcr.newSession();
-        this.rootNode = this.session.getRootNode();
-        this.node1 = this.rootNode.addNode("node1");
-    }
+public class MockPropertyTest extends AbstractItemTest {
 
     @Test
     public void testRemove() throws RepositoryException {
@@ -402,6 +388,24 @@ public class MockPropertyTest {
         Property prop1 = this.node1.getProperty("prop1");
         assertFalse(prop1.isMultiple());
         assertEquals("value1", prop1.getValues()[0].getString());
+    }
+
+    @Test
+    public void testIsSameForPropComparedToItself() throws RepositoryException {
+        assertTrue(this.prop1.isSame(this.prop1));
+    }
+
+    @Test
+    public void testIsSameForPropComparedToSameProp() throws RepositoryException {
+        // a different object referencing the same property
+        Property prop1Ref = this.node1.getProperty("prop1");
+        assertTrue(this.prop1.isSame(prop1Ref));
+    }
+
+    @Test
+    public void testIsSameForPropComparedToDifferentProp() throws RepositoryException {
+        Property prop11 = this.node11.setProperty("prop1", "value1");
+        assertFalse(this.prop1.isSame(prop11));
     }
 
 }

--- a/src/test/java/org/apache/sling/testing/mock/jcr/MockPropertyTest.java
+++ b/src/test/java/org/apache/sling/testing/mock/jcr/MockPropertyTest.java
@@ -29,9 +29,12 @@ import java.io.InputStream;
 import java.math.BigDecimal;
 import java.util.Calendar;
 
+import javax.jcr.Node;
 import javax.jcr.Property;
 import javax.jcr.PropertyType;
+import javax.jcr.Repository;
 import javax.jcr.RepositoryException;
+import javax.jcr.Session;
 import javax.jcr.Value;
 import javax.jcr.ValueFormatException;
 
@@ -403,9 +406,35 @@ public class MockPropertyTest extends AbstractItemTest {
     }
 
     @Test
-    public void testIsSameForPropComparedToDifferentProp() throws RepositoryException {
+    public void testIsSameForPropComparedToDifferentPropFromSameParent() throws RepositoryException {
+        Property prop2 = this.node1.setProperty("prop2", "value2");
+        assertFalse(this.prop1.isSame(prop2));
+    }
+
+    @Test
+    public void testIsSameForPropComparedToPropFromDifferentParent() throws RepositoryException {
         Property prop11 = this.node11.setProperty("prop1", "value1");
         assertFalse(this.prop1.isSame(prop11));
+    }
+
+    @Test
+    public void testIsSameForPropFromDifferentRepository() throws RepositoryException {
+        Repository otherRepository = MockJcr.newRepository();
+        Session otherSession = otherRepository.login();
+        Node otherNode1 = otherSession.getRootNode().addNode("node1");
+        Property otherProp1 = otherNode1.setProperty("prop1", "value1");
+
+        assertFalse(this.prop1.isSame(otherProp1));
+    }
+
+    @Test
+    public void testIsSameForPropFromDifferentWorkspace() throws RepositoryException {
+        Session otherSession = session.getRepository().login("otherWorkspace");
+        Node otherRootNode = otherSession.getRootNode();
+        Node otherNode1 = otherRootNode.addNode("node1");
+        Property otherProp1 = otherNode1.setProperty("prop1", "value1");
+
+        assertFalse(this.prop1.isSame(otherProp1));
     }
 
 }


### PR DESCRIPTION
Add basic support for the item#isSame API into the JCR Mock library.