### PR TITLE
SLING-11807 mocking-queries whose result iterator size is not known

### DIFF
--- a/src/main/java/org/apache/sling/testing/mock/jcr/MockJcr.java
+++ b/src/main/java/org/apache/sling/testing/mock/jcr/MockJcr.java
@@ -101,15 +101,37 @@ public final class MockJcr {
 
     /**
      * Sets the expected result list for all queries executed with the given query manager.
+     * @param session JCR session
+     * @param resultList Result list
+     * @param simulateUnknownSize true to simulate the result iterator having an unknown size
+     */
+    public static void setQueryResult(@NotNull final Session session, @NotNull final List<Node> resultList,
+            boolean simulateUnknownSize) {
+        setQueryResult(getQueryManager(session), resultList, simulateUnknownSize);
+    }
+
+
+    /**
+     * Sets the expected result list for all queries executed with the given query manager.
      * @param queryManager Mocked query manager
      * @param resultList Result list
      */
     public static void setQueryResult(@NotNull final QueryManager queryManager, @NotNull final List<Node> resultList) {
-        addQueryResultHandler(queryManager, new MockQueryResultHandler() {
-            @Override
-            public MockQueryResult executeQuery(MockQuery query) {
-                return new MockQueryResult(resultList);
-            }
+        setQueryResult(queryManager, resultList, false);
+    }
+
+    /**
+     * Sets the expected result list for all queries executed with the given query manager.
+     * @param queryManager Mocked query manager
+     * @param resultList Result list
+     * @param simulateUnknownSize true to simulate the result iterator having an unknown size
+     */
+    public static void setQueryResult(@NotNull final QueryManager queryManager, @NotNull final List<Node> resultList,
+            boolean simulateUnknownSize) {
+        addQueryResultHandler(queryManager, query -> {
+            MockQueryResult result = new MockQueryResult(resultList);
+            result.setSimulateUnknownSize(simulateUnknownSize);
+            return result;
         });
     }
 
@@ -122,7 +144,21 @@ public final class MockJcr {
      */
     public static void setQueryResult(@NotNull final Session session, @NotNull final String statement,
             @NotNull final String language, @NotNull final List<Node> resultList) {
-        setQueryResult(getQueryManager(session), statement, language, resultList);
+        setQueryResult(session, statement, language, resultList, false);
+    }
+
+    /**
+     * Sets the expected result list for all queries with the given statement executed with the given query manager.
+     * @param session JCR session
+     * @param statement Query statement
+     * @param language Query language
+     * @param resultList Result list
+     * @param simulateUnknownSize true to simulate the result iterator having an unknown size
+     */
+    public static void setQueryResult(@NotNull final Session session, @NotNull final String statement,
+            @NotNull final String language, @NotNull final List<Node> resultList,
+            boolean simulateUnknownSize) {
+        setQueryResult(getQueryManager(session), statement, language, resultList, simulateUnknownSize);
     }
 
     /**
@@ -134,16 +170,28 @@ public final class MockJcr {
      */
     public static void setQueryResult(@NotNull final QueryManager queryManager, @NotNull final String statement,
             @NotNull final String language, @NotNull final List<Node> resultList) {
-        addQueryResultHandler(queryManager, new MockQueryResultHandler() {
-            @Override
-            public MockQueryResult executeQuery(MockQuery query) {
-                if (StringUtils.equals(query.getStatement(), statement)
-                        && StringUtils.equals(query.getLanguage(), language)) {
-                    return new MockQueryResult(resultList);
-                }
-                else {
-                    return null;
-                }
+        setQueryResult(queryManager, statement, language, resultList, false);
+    }
+    /**
+     * Sets the expected result list for all queries with the given statement executed with the given query manager.
+     * @param queryManager Mocked query manager
+     * @param statement Query statement
+     * @param language Query language
+     * @param resultList Result list
+     * @param simulateUnknownSize true to simulate the result iterator having an unknown size
+     */
+    public static void setQueryResult(@NotNull final QueryManager queryManager, @NotNull final String statement,
+            @NotNull final String language, @NotNull final List<Node> resultList,
+            boolean simulateUnknownSize) {
+        addQueryResultHandler(queryManager, query -> {
+            if (StringUtils.equals(query.getStatement(), statement)
+                    && StringUtils.equals(query.getLanguage(), language)) {
+                MockQueryResult mockQueryResult = new MockQueryResult(resultList);
+                mockQueryResult.setSimulateUnknownSize(simulateUnknownSize);
+                return mockQueryResult;
+            }
+            else {
+                return null;
             }
         });
     }

--- a/src/main/java/org/apache/sling/testing/mock/jcr/MockQueryResult.java
+++ b/src/main/java/org/apache/sling/testing/mock/jcr/MockQueryResult.java
@@ -41,6 +41,7 @@ public final class MockQueryResult implements QueryResult {
 
     private final List<Node> nodes;
     private final List<String> columnNames;
+    private boolean simulateUnknownSize;
 
     public MockQueryResult(List<Node> nodes) {
         this(nodes, Collections.emptyList());
@@ -49,6 +50,10 @@ public final class MockQueryResult implements QueryResult {
     public MockQueryResult(List<Node> nodes, List<String> columnNames) {
         this.columnNames = columnNames;
         this.nodes = nodes;
+    }
+
+    public void setSimulateUnknownSize(boolean simulateUnknownSize) {
+        this.simulateUnknownSize = simulateUnknownSize;
     }
 
     @Override
@@ -65,7 +70,11 @@ public final class MockQueryResult implements QueryResult {
 
     @Override
     public NodeIterator getNodes() throws RepositoryException {
-        return new NodeIteratorAdapter(nodes);
+        if (simulateUnknownSize) {
+            return new NodeIteratorAdapter(nodes.iterator(), -1);
+        } else {
+            return new NodeIteratorAdapter(nodes);
+        }
     }
 
     @Override

--- a/src/main/java/org/apache/sling/testing/mock/jcr/package-info.java
+++ b/src/main/java/org/apache/sling/testing/mock/jcr/package-info.java
@@ -19,5 +19,5 @@
 /**
  * Mock implementation of selected JCR APIs.
  */
-@org.osgi.annotation.versioning.Version("1.0.2")
+@org.osgi.annotation.versioning.Version("1.1.0")
 package org.apache.sling.testing.mock.jcr;

--- a/src/test/java/org/apache/sling/testing/mock/jcr/MockQueryManagerTest.java
+++ b/src/test/java/org/apache/sling/testing/mock/jcr/MockQueryManagerTest.java
@@ -85,11 +85,25 @@ public class MockQueryManagerTest {
         QueryResult result = assertQueryResults_AllQuerys();
         assertEquals(sampleNodes.size(), result.getNodes().getSize());
     }
+    @Test
+    public void testQueryResultsForSession_AllQuerys() throws RepositoryException {
+        MockJcr.setQueryResult(session, sampleNodes);
+
+        QueryResult result = assertQueryResults_AllQuerys();
+        assertEquals(sampleNodes.size(), result.getNodes().getSize());
+    }
 
     // SLING-11807
     @Test
     public void testQueryResults_AllQuerys_WithUnknownSize() throws RepositoryException {
         MockJcr.setQueryResult(queryManager, sampleNodes, true);
+
+        QueryResult result = assertQueryResults_AllQuerys();
+        assertEquals(-1, result.getNodes().getSize());
+    }
+    @Test
+    public void testQueryResultsForSession_AllQuerys_WithUnknownSize() throws RepositoryException {
+        MockJcr.setQueryResult(session, sampleNodes, true);
 
         QueryResult result = assertQueryResults_AllQuerys();
         assertEquals(-1, result.getNodes().getSize());
@@ -107,10 +121,16 @@ public class MockQueryManagerTest {
         return result;
     }
 
-    @SuppressWarnings("unchecked")
     @Test
     public void testQueryResults_SpecificQuery() throws RepositoryException {
         MockJcr.setQueryResult(queryManager, "query1", Query.JCR_SQL2, sampleNodes);
+
+        QueryResult result = assertQueryResults_SpecificQuery();
+        assertEquals(sampleNodes.size(), result.getNodes().getSize());
+    }
+    @Test
+    public void testQueryResultsForSession_SpecificQuery() throws RepositoryException {
+        MockJcr.setQueryResult(session, "query1", Query.JCR_SQL2, sampleNodes);
 
         QueryResult result = assertQueryResults_SpecificQuery();
         assertEquals(sampleNodes.size(), result.getNodes().getSize());
@@ -120,6 +140,13 @@ public class MockQueryManagerTest {
     @Test
     public void testQueryResults_SpecificQuery_WithUnknownSize() throws RepositoryException {
         MockJcr.setQueryResult(queryManager, "query1", Query.JCR_SQL2, sampleNodes, true);
+
+        QueryResult result = assertQueryResults_SpecificQuery();
+        assertEquals(-1, result.getNodes().getSize());
+    }
+    @Test
+    public void testQueryResultsForSession_SpecificQuery_WithUnknownSize() throws RepositoryException {
+        MockJcr.setQueryResult(session, "query1", Query.JCR_SQL2, sampleNodes, true);
 
         QueryResult result = assertQueryResults_SpecificQuery();
         assertEquals(-1, result.getNodes().getSize());


### PR DESCRIPTION
Implement the ability to mock queries that return results where the number of elements may not be available. In such cases the iterator#getSize method must return -1
