### PR TITLE
SLING-11828 Allow setting an AccessControlManager on the MockSession

### DIFF
--- a/src/main/java/org/apache/sling/testing/mock/jcr/MockJcr.java
+++ b/src/main/java/org/apache/sling/testing/mock/jcr/MockJcr.java
@@ -30,6 +30,7 @@ import javax.jcr.SimpleCredentials;
 import javax.jcr.nodetype.NodeTypeManager;
 import javax.jcr.nodetype.NodeTypeTemplate;
 import javax.jcr.query.QueryManager;
+import javax.jcr.security.AccessControlManager;
 
 import org.apache.commons.lang3.StringUtils;
 import org.apache.jackrabbit.commons.cnd.CompactNodeTypeDefReader;
@@ -253,4 +254,13 @@ public final class MockJcr {
         }
     }
 
+    /**
+     * Use the supplied AccessControlManager for the session
+     * 
+     * @param session the session to modify
+     * @param acm the access control manager to use for the session
+     */
+    public static void setAccessControlManager(@NotNull Session session, @Nullable AccessControlManager acm) {
+        ((MockSession)session).setAccessControlManager(acm);
+    }
 }

--- a/src/main/java/org/apache/sling/testing/mock/jcr/MockSession.java
+++ b/src/main/java/org/apache/sling/testing/mock/jcr/MockSession.java
@@ -63,6 +63,7 @@ class MockSession implements Session {
     private final String userId;
     private boolean isLive;
     private boolean hasKnownChanges;
+    private AccessControlManager accessControlManager = null;
 
     public MockSession(MockRepository repository, Map<String, ItemData> items,
             String userId, String workspaceName) throws RepositoryException {
@@ -479,7 +480,11 @@ class MockSession implements Session {
 
     @Override
     public AccessControlManager getAccessControlManager() throws RepositoryException {
-        throw new UnsupportedOperationException();
+        if (accessControlManager == null) {
+            // not set, so fallback to thrown exception
+            throw new UnsupportedOperationException();
+        }
+        return accessControlManager;
     }
 
     @Override
@@ -497,4 +502,11 @@ class MockSession implements Session {
         throw new UnsupportedOperationException();
     }
 
+    /**
+     * To allow a test to provide mock implementation of the AccessControlManager
+     * @param acm the access control manager to use for the session
+     */
+    public void setAccessControlManager(AccessControlManager acm) {
+        this.accessControlManager = acm;
+    }
 }

--- a/src/test/java/org/apache/sling/testing/mock/jcr/MockSessionTest.java
+++ b/src/test/java/org/apache/sling/testing/mock/jcr/MockSessionTest.java
@@ -34,9 +34,11 @@ import javax.jcr.PathNotFoundException;
 import javax.jcr.Property;
 import javax.jcr.RepositoryException;
 import javax.jcr.Session;
+import javax.jcr.security.AccessControlManager;
 
 import org.apache.jackrabbit.JcrConstants;
 import org.junit.Test;
+import org.mockito.Mockito;
 
 import com.google.common.collect.ImmutableSet;
 
@@ -407,6 +409,17 @@ public class MockSessionTest {
         assertTrue(session.propertyExists("/node1/child2/prop1"));
         assertTrue(session.nodeExists("/node1/child2/grandchild1"));
         assertTrue(session.propertyExists("/node1/child2/grandchild1/prop1"));
+    }
+
+    @Test
+    public void testSetAccessControlManager() throws RepositoryException {
+        Session s = MockJcr.newSession();
+        assertThrows(UnsupportedOperationException.class, () -> s.getAccessControlManager());
+
+        AccessControlManager mockAccessControlManager = Mockito.mock(AccessControlManager.class);
+        MockJcr.setAccessControlManager(s, mockAccessControlManager);
+
+        assertEquals(mockAccessControlManager, s.getAccessControlManager());
     }
 
 }


### PR DESCRIPTION
Provide a mechanism to set an AccessControlManager on the MockSession for testing of code paths that interact with AccessControlManager apis.

For example:
```
AccessControlManager mockAccessControlManager = Mockito.mock(AccessControlManager.class);
MockJcr.setAccessControlManager(session, mockAccessControlManager);
```