### PR TITLE
SLING-11863 getAncestor interprets the depth argument incorrectly

### DIFF
--- a/src/main/java/org/apache/sling/testing/mock/jcr/AbstractItem.java
+++ b/src/main/java/org/apache/sling/testing/mock/jcr/AbstractItem.java
@@ -76,7 +76,7 @@ abstract class AbstractItem implements Item {
         if (depth < 0 || depth > getDepth()) {
             throw new ItemNotFoundException();
         }
-        return this.session.getItem(ResourceUtil.getParent(getPath(), depth));
+        return this.session.getItem(ResourceUtil.getParent(getPath(), getDepth() - depth));
     }
 
     protected String makeAbsolutePath(final String relativePath) throws RepositoryException {

--- a/src/test/java/org/apache/sling/testing/mock/jcr/AbstractItemTest.java
+++ b/src/test/java/org/apache/sling/testing/mock/jcr/AbstractItemTest.java
@@ -20,7 +20,7 @@ package org.apache.sling.testing.mock.jcr;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertSame;
+import static org.junit.Assert.assertThrows;
 import static org.junit.Assert.assertTrue;
 
 import javax.jcr.ItemNotFoundException;
@@ -64,19 +64,21 @@ public abstract class AbstractItemTest {
 
     @Test
     public void testGetAncestor() throws RepositoryException {
-        assertTrue(this.node11.isSame(this.node11.getAncestor(0)));
+        assertTrue(this.rootNode.isSame(this.node11.getAncestor(0)));
         assertTrue(this.node1.isSame(this.node11.getAncestor(1)));
-        assertTrue(this.rootNode.isSame(this.node11.getAncestor(2)));
+        assertTrue(this.node11.isSame(this.node11.getAncestor(2)));
     }
 
-    @Test(expected = ItemNotFoundException.class)
+    @Test
     public void testGetAncestorNegative() throws RepositoryException {
-        assertSame(this.node11, this.node11.getAncestor(-1));
+        assertThrows(ItemNotFoundException.class,
+                () -> this.node11.getAncestor(-1));
     }
 
-    @Test(expected = ItemNotFoundException.class)
+    @Test
     public void testGetAncestorTooDeep() throws RepositoryException {
-        this.node11.getAncestor(3);
+        assertThrows(ItemNotFoundException.class,
+                () -> this.node11.getAncestor(3));
     }
 
     @Test


### PR DESCRIPTION
The [javadocs](https://javadoc.io/static/javax.jcr/jcr/2.0/javax/jcr/Item.html#getAncestor(int)) for "Item javax.jcr.Item.getAncestor(int depth)" describes the depth argument as:
```
depth = 0 returns the root node of a workspace.
depth = 1 returns the child of the root node along the path to this Item.
depth = 2 returns the grandchild of the root node along the path to this Item.
And so on to depth = n, where n is the depth of this Item, which returns this Item itself.
```

However, the org.apache.sling.testing.mock.jcr.AbstractItem#getAncestor implementation is using "ResourceUtil.getParent(getPath(), depth)" which interprets the second argument as:
```
level = 0 returns the path.
level = 1 returns the parent of path, if it exists, null otherwise.
level = 2 returns the grandparent of path, if it exists, null otherwise.
 ```

Expected:
AbstractItem#getAncestor should resolve the ancestor path as the item depth minus the supplied depth argument.
```
this.session.getItem(ResourceUtil.getParent(getPath(), getDepth() - depth));
```