### PR TITLE
SLING-11869 MockUserManager should load and save home folder items

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -76,6 +76,12 @@
             <version>1.22.5</version>
             <scope>compile</scope>
         </dependency>
+        <dependency>
+            <groupId>org.apache.jackrabbit</groupId>
+            <artifactId>oak-security-spi</artifactId>
+            <version>1.22.5</version>
+            <scope>compile</scope>
+        </dependency>
 
         <dependency>
             <groupId>org.apache.commons</groupId>

--- a/src/main/java/org/apache/sling/testing/mock/jcr/MockAuthorizable.java
+++ b/src/main/java/org/apache/sling/testing/mock/jcr/MockAuthorizable.java
@@ -16,21 +16,23 @@
  */
 package org.apache.sling.testing.mock.jcr;
 
-import java.nio.file.Paths;
 import java.security.Principal;
-import java.util.HashMap;
+import java.util.Arrays;
 import java.util.HashSet;
 import java.util.Iterator;
-import java.util.Map;
 import java.util.Set;
-import java.util.stream.Collectors;
 
+import javax.jcr.Node;
+import javax.jcr.Property;
+import javax.jcr.PropertyIterator;
 import javax.jcr.RepositoryException;
 import javax.jcr.Value;
 
+import org.apache.jackrabbit.JcrConstants;
+import org.apache.jackrabbit.api.security.principal.PrincipalManager;
 import org.apache.jackrabbit.api.security.user.Authorizable;
 import org.apache.jackrabbit.api.security.user.Group;
-import org.apache.jackrabbit.value.ValueFactoryImpl;
+import org.apache.jackrabbit.oak.spi.security.user.UserConstants;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
@@ -38,16 +40,19 @@ import org.jetbrains.annotations.Nullable;
  * Mock {@link Authorizable} implementation.
  */
 abstract class MockAuthorizable implements Authorizable {
-    static final String REP_PRINCIPAL_NAME = "rep:principalName";
+    // internal property names to filter out of the authorizable properties
+    protected Set<String> notAuthorizablePropNames = new HashSet<>(Arrays.asList(
+            JcrConstants.JCR_PRIMARYTYPE,
+            UserConstants.REP_AUTHORIZABLE_ID,
+            UserConstants.REP_PRINCIPAL_NAME));
+
     protected String id;
     protected Principal principal;
-    protected String path;
     protected MockUserManager mockUserMgr;
-    protected Map<String, Value[]> propsMap = new HashMap<>();
-    protected Set<Group> declaredMemberOf = new HashSet<>();
+    protected Node homeNode;
 
     MockAuthorizable(@Nullable String id, @Nullable Principal principal,
-            @Nullable String intermediatePath,
+            @NotNull Node homeNode,
             @NotNull MockUserManager mockUserMgr) {
         this.principal = principal;
         if (id == null && principal != null) {
@@ -59,19 +64,8 @@ abstract class MockAuthorizable implements Authorizable {
             this.principal = () -> this.id;
         }
 
-        if (intermediatePath == null) {
-            // use a default intermediate path when none supplied
-            if (isGroup()) {
-                intermediatePath = "/home/groups"; // NOSONAR
-            } else {
-                intermediatePath = "/home/users"; // NOSONAR
-            }
-        }
-        this.path = Paths.get(intermediatePath, this.id).toString();
+        this.homeNode = homeNode;
         this.mockUserMgr = mockUserMgr;
-
-        // pre-populate the principalName property that is needed by MockPrincipalManager#findPrincipals
-        propsMap.put(REP_PRINCIPAL_NAME, new Value[] {ValueFactoryImpl.getInstance().createValue(this.id)});
     }
 
     @Override
@@ -91,6 +85,14 @@ abstract class MockAuthorizable implements Authorizable {
 
     @Override
     public @NotNull Iterator<Group> declaredMemberOf() throws RepositoryException {
+        Set<Group> declaredMemberOf = new HashSet<>();
+        Set<Authorizable> all = mockUserMgr.all(PrincipalManager.SEARCH_TYPE_GROUP);
+        for (Authorizable authorizable : all) {
+            Group group = (Group)authorizable;
+            if (group.isDeclaredMember(this)) {
+                declaredMemberOf.add(group);
+            }
+        }
         return declaredMemberOf.iterator();
     }
 
@@ -131,52 +133,85 @@ abstract class MockAuthorizable implements Authorizable {
 
     @Override
     public @NotNull Iterator<String> getPropertyNames() throws RepositoryException {
-        Set<String> propNames = propsMap.keySet().stream()
-                .filter(key -> key.indexOf('/') == -1)
-                .collect(Collectors.toSet());
-            return propNames.iterator();
+        Set<String> propNames = new HashSet<>();
+        PropertyIterator properties = homeNode.getProperties();
+        while (properties.hasNext()) {
+            Property nextProperty = properties.nextProperty();
+            if (!notAuthorizablePropNames.contains(nextProperty.getName())) {
+                propNames.add(nextProperty.getName());
+            }
+        }
+        return propNames.iterator();
     }
 
     @Override
     public @NotNull Iterator<String> getPropertyNames(@NotNull String relPath) throws RepositoryException {
-        Set<String> propNames = propsMap.keySet().stream()
-            .filter(key -> key.startsWith(relPath))
-            .collect(Collectors.toSet());
+        Set<String> propNames = new HashSet<>();
+        if (homeNode.hasNode(relPath)) {
+            PropertyIterator properties = homeNode.getNode(relPath).getProperties();
+            while (properties.hasNext()) {
+                Property nextProperty = properties.nextProperty();
+                if (!notAuthorizablePropNames.contains(nextProperty.getName())) {
+                    propNames.add(nextProperty.getName());
+                }
+            }
+        }
         return propNames.iterator();
     }
 
     @Override
     public boolean hasProperty(@NotNull String relPath) throws RepositoryException {
-        return propsMap.containsKey(relPath);
+        return homeNode.hasProperty(relPath);
     }
 
     @Override
     public void setProperty(@NotNull String relPath, @Nullable Value value) throws RepositoryException {
-        propsMap.put(relPath, new Value[] {value});
+        String[] segments = relPath.split("/");
+        Node node = homeNode;
+        for (int i = 0; i < segments.length - 1; i++) {
+            String segment = segments[i];
+            if (node.hasNode(segment)) {
+                node = node.getNode(segment);
+            } else {
+                node = node.addNode(segment, UserConstants.NT_REP_AUTHORIZABLE_FOLDER);
+            }
+        }
+        String propName = segments[segments.length - 1];
+        node.setProperty(propName, value);
     }
 
     @Override
     public void setProperty(@NotNull String relPath, @Nullable Value[] value) throws RepositoryException {
-        propsMap.put(relPath, value);
+        homeNode.setProperty(relPath, value);
     }
 
     @Override
     public @Nullable Value[] getProperty(@NotNull String relPath) throws RepositoryException {
-        return propsMap.get(relPath);
+        if (homeNode.hasProperty(relPath)) {
+            Property property = homeNode.getProperty(relPath);
+            if (property.isMultiple()) {
+                return property.getValues();
+            } else {
+                return new Value[] {property.getValue()};
+            }
+        } else {
+            return null;
+        }
     }
 
     @Override
     public boolean removeProperty(@NotNull String relPath) throws RepositoryException {
-        return propsMap.remove(relPath) != null;
+        boolean removed = false;
+        if (homeNode.hasProperty(relPath)) {
+            homeNode.getProperty(relPath).remove();
+            removed = true;
+        }
+        return removed;
     }
 
     @Override
     public @NotNull String getPath() throws RepositoryException {
-        return path;
-    }
-
-    public void addDeclaredMemberOf(Group group) {
-        declaredMemberOf.add(group);
+        return homeNode.getPath();
     }
 
 }

--- a/src/main/java/org/apache/sling/testing/mock/jcr/MockGroup.java
+++ b/src/main/java/org/apache/sling/testing/mock/jcr/MockGroup.java
@@ -23,6 +23,7 @@ import java.util.Iterator;
 import java.util.Map;
 import java.util.Set;
 
+import javax.jcr.Node;
 import javax.jcr.RepositoryException;
 
 import org.apache.jackrabbit.api.security.user.Authorizable;
@@ -37,9 +38,9 @@ class MockGroup extends MockAuthorizable implements Group {
     private Map<String, Authorizable> declaredMembers = new HashMap<>();
 
     public MockGroup(@Nullable String id, @Nullable Principal principal,
-            @Nullable String intermediatePath,
+            @NotNull Node homeNode,
             @NotNull MockUserManager mockUserMgr) {
-        super(id, principal, intermediatePath, mockUserMgr);
+        super(id, principal, homeNode, mockUserMgr);
     }
 
     @Override
@@ -107,7 +108,6 @@ class MockGroup extends MockAuthorizable implements Group {
         boolean added = false;
         if (!isMember(authorizable)) {
             declaredMembers.put(authorizable.getID(), authorizable);
-            ((MockAuthorizable)authorizable).addDeclaredMemberOf(this);
             added = true;
         }
         return added;

--- a/src/main/java/org/apache/sling/testing/mock/jcr/MockPrincipalManager.java
+++ b/src/main/java/org/apache/sling/testing/mock/jcr/MockPrincipalManager.java
@@ -30,6 +30,7 @@ import org.apache.jackrabbit.api.security.user.Authorizable;
 import org.apache.jackrabbit.api.security.user.Group;
 import org.apache.jackrabbit.api.security.user.UserManager;
 import org.apache.jackrabbit.commons.iterator.RangeIteratorAdapter;
+import org.apache.jackrabbit.oak.spi.security.user.UserConstants;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 import org.slf4j.Logger;
@@ -57,7 +58,7 @@ public class MockPrincipalManager implements PrincipalManager {
         Set<Principal> principals = new HashSet<>();
         try {
             @NotNull Iterator<Authorizable> authorizables = mockUserManager.findAuthorizables(
-                    MockAuthorizable.REP_PRINCIPAL_NAME, simpleFilter, searchType);
+                    UserConstants.REP_PRINCIPAL_NAME, simpleFilter, searchType);
             while (authorizables.hasNext()) {
                 Authorizable next = authorizables.next();
                 principals.add(next.getPrincipal());

--- a/src/main/java/org/apache/sling/testing/mock/jcr/MockSession.java
+++ b/src/main/java/org/apache/sling/testing/mock/jcr/MockSession.java
@@ -75,11 +75,12 @@ class MockSession implements Session, JackrabbitSession {
             String userId, String workspaceName) throws RepositoryException {
         this.repository = repository;
         this.workspace = new MockWorkspace(repository, this, workspaceName);
-        this.userManager = new MockUserManager();
+        this.userManager = new MockUserManager(this);
         this.principalManager = new MockPrincipalManager(this.userManager);
         this.items = items;
         this.userId = userId;
         isLive = true;
+        this.userManager.loadAlreadyExistingAuthorizables();
         hasKnownChanges = false;
         this.save();
     }

--- a/src/main/java/org/apache/sling/testing/mock/jcr/MockUser.java
+++ b/src/main/java/org/apache/sling/testing/mock/jcr/MockUser.java
@@ -20,6 +20,7 @@ import java.security.Principal;
 import java.util.Arrays;
 
 import javax.jcr.Credentials;
+import javax.jcr.Node;
 import javax.jcr.RepositoryException;
 import javax.jcr.SimpleCredentials;
 
@@ -40,9 +41,9 @@ class MockUser extends MockAuthorizable implements User {
     private String disabledReason;
 
     public MockUser(@Nullable String id, @Nullable Principal principal,
-            @Nullable String intermediatePath,
+            @NotNull Node homeNode,
             @NotNull MockUserManager mockUserMgr) {
-        super(id, principal, intermediatePath, mockUserMgr);
+        super(id, principal, homeNode, mockUserMgr);
     }
 
     @Override

--- a/src/main/java/org/apache/sling/testing/mock/jcr/package-info.java
+++ b/src/main/java/org/apache/sling/testing/mock/jcr/package-info.java
@@ -19,5 +19,5 @@
 /**
  * Mock implementation of selected JCR APIs.
  */
-@org.osgi.annotation.versioning.Version("1.2.0")
+@org.osgi.annotation.versioning.Version("1.3.0")
 package org.apache.sling.testing.mock.jcr;

--- a/src/test/java/org/apache/sling/testing/mock/jcr/MockAuthorizableTest.java
+++ b/src/test/java/org/apache/sling/testing/mock/jcr/MockAuthorizableTest.java
@@ -28,6 +28,7 @@ import java.util.Iterator;
 import java.util.Set;
 
 import javax.jcr.RepositoryException;
+import javax.jcr.Session;
 import javax.jcr.UnsupportedRepositoryOperationException;
 import javax.jcr.Value;
 import javax.jcr.ValueFactory;
@@ -45,13 +46,15 @@ import org.junit.Test;
  *
  */
 public abstract class MockAuthorizableTest<T extends Authorizable> {
+    protected Session session;
     protected UserManager userManager;
     protected T authorizable;
     protected ValueFactory vf = ValueFactoryImpl.getInstance();
 
     @Before
     public void before() throws RepositoryException {
-        userManager = new MockUserManager();
+        session = MockJcr.newSession();
+        userManager = new MockUserManager(session);
         authorizable = createAuthorizable();
     }
 
@@ -131,13 +134,9 @@ public abstract class MockAuthorizableTest<T extends Authorizable> {
      */
     @Test
     public void testGetPropertyNames() throws RepositoryException {
-        // only rep:principalName property
+        // no properties
         @NotNull Iterator<String> propertyNames = authorizable.getPropertyNames();
-        assertTrue(propertyNames.hasNext());
-        Set<String> propertyNamesSet = new HashSet<>();
-        propertyNames.forEachRemaining(propertyNamesSet::add);
-        assertEquals(1, propertyNamesSet.size());
-        assertTrue(propertyNamesSet.contains(MockAuthorizable.REP_PRINCIPAL_NAME));
+        assertFalse(propertyNames.hasNext());
 
         // set some props
         authorizable.setProperty("prop1", vf.createValue("value1"));
@@ -145,9 +144,9 @@ public abstract class MockAuthorizableTest<T extends Authorizable> {
 
         propertyNames = authorizable.getPropertyNames();
         assertTrue(propertyNames.hasNext());
-        propertyNamesSet.clear();
+        Set<String> propertyNamesSet = new HashSet<>();
         propertyNames.forEachRemaining(propertyNamesSet::add);
-        assertEquals(2, propertyNamesSet.size());
+        assertEquals(1, propertyNamesSet.size());
         assertTrue(propertyNamesSet.contains("prop1"));
     }
 
@@ -169,7 +168,7 @@ public abstract class MockAuthorizableTest<T extends Authorizable> {
         Set<String> propertyNamesSet = new HashSet<>();
         propertyNames.forEachRemaining(propertyNamesSet::add);
         assertEquals(1, propertyNamesSet.size());
-        assertTrue(propertyNamesSet.contains("relPath/prop2"));
+        assertTrue(propertyNamesSet.contains("prop2"));
     }
 
     /**

--- a/src/test/java/org/apache/sling/testing/mock/jcr/MockAuthorizableTest.java
+++ b/src/test/java/org/apache/sling/testing/mock/jcr/MockAuthorizableTest.java
@@ -191,6 +191,20 @@ public abstract class MockAuthorizableTest<T extends Authorizable> {
         assertNotNull(property);
         assertEquals(1, property.length);
         assertEquals("value1", property[0].getString());
+
+        // nested prop
+        authorizable.setProperty("relPath2/prop2", vf.createValue("value2"));
+        property = authorizable.getProperty("relPath2/prop2");
+        assertNotNull(property);
+        assertEquals(1, property.length);
+        assertEquals("value2", property[0].getString());
+
+        // second nested prop where intermediate subnode already exists
+        authorizable.setProperty("relPath2/prop3", vf.createValue("value3"));
+        property = authorizable.getProperty("relPath2/prop3");
+        assertNotNull(property);
+        assertEquals(1, property.length);
+        assertEquals("value3", property[0].getString());
     }
 
     /**

--- a/src/test/java/org/apache/sling/testing/mock/jcr/MockGroupTest.java
+++ b/src/test/java/org/apache/sling/testing/mock/jcr/MockGroupTest.java
@@ -24,6 +24,7 @@ import java.util.HashSet;
 import java.util.Iterator;
 import java.util.Set;
 
+import javax.jcr.Node;
 import javax.jcr.RepositoryException;
 import javax.jcr.UnsupportedRepositoryOperationException;
 
@@ -31,6 +32,7 @@ import org.apache.jackrabbit.api.security.user.Authorizable;
 import org.apache.jackrabbit.api.security.user.AuthorizableExistsException;
 import org.apache.jackrabbit.api.security.user.Group;
 import org.apache.jackrabbit.api.security.user.User;
+import org.apache.jackrabbit.oak.spi.security.user.UserConstants;
 import org.jetbrains.annotations.NotNull;
 import org.junit.Test;
 
@@ -240,6 +242,10 @@ public class MockGroupTest extends MockAuthorizableTest<Group> {
     @Override
     public void testGetPath() throws UnsupportedRepositoryOperationException, RepositoryException {
         assertEquals("/home/groups/group1", authorizable.getPath());
+        assertTrue(session.nodeExists(authorizable.getPath()));
+        Node node = session.getNode(authorizable.getPath());
+        assertEquals(authorizable.getID(), 
+                node.getProperty(UserConstants.REP_PRINCIPAL_NAME).getString());
     }
 
 }

--- a/src/test/java/org/apache/sling/testing/mock/jcr/MockPrincipalManagerTest.java
+++ b/src/test/java/org/apache/sling/testing/mock/jcr/MockPrincipalManagerTest.java
@@ -30,6 +30,7 @@ import java.util.HashSet;
 import java.util.Set;
 
 import javax.jcr.RepositoryException;
+import javax.jcr.Session;
 
 import org.apache.jackrabbit.api.security.principal.PrincipalIterator;
 import org.apache.jackrabbit.api.security.principal.PrincipalManager;
@@ -48,12 +49,14 @@ import ch.qos.logback.classic.Level;
  *
  */
 public class MockPrincipalManagerTest {
+    protected Session session;
     protected UserManager userManager;
     protected MockPrincipalManager principalManager;
 
     @Before
     public void before() throws RepositoryException {
-        userManager = new MockUserManager();
+        session = MockJcr.newSession();
+        userManager = new MockUserManager(session);
         principalManager = new MockPrincipalManager((MockUserManager)userManager);
     }
 

--- a/src/test/java/org/apache/sling/testing/mock/jcr/MockUserManagerTest.java
+++ b/src/test/java/org/apache/sling/testing/mock/jcr/MockUserManagerTest.java
@@ -27,6 +27,7 @@ import java.util.Iterator;
 import java.util.Set;
 
 import javax.jcr.RepositoryException;
+import javax.jcr.Session;
 import javax.jcr.UnsupportedRepositoryOperationException;
 import javax.jcr.ValueFactory;
 
@@ -50,12 +51,14 @@ import ch.qos.logback.classic.Level;
  *
  */
 public class MockUserManagerTest {
+    protected Session session;
     protected MockUserManager userManager;
     protected ValueFactory vf = ValueFactoryImpl.getInstance();
 
     @Before
     public void before() throws RepositoryException {
-        userManager = new MockUserManager();
+        session = MockJcr.newSession();
+        userManager = new MockUserManager(session);
     }
 
     /**

--- a/src/test/java/org/apache/sling/testing/mock/jcr/MockUserManagerTest.java
+++ b/src/test/java/org/apache/sling/testing/mock/jcr/MockUserManagerTest.java
@@ -68,6 +68,7 @@ public class MockUserManagerTest {
      */
     @SuppressWarnings("deprecation")
     @Deprecated
+    @Test
     public void testDeprecatedConstructor() {
         assertThrows(UnsupportedOperationException.class, () -> new MockUserManager());
     }

--- a/src/test/java/org/apache/sling/testing/mock/jcr/MockUserTest.java
+++ b/src/test/java/org/apache/sling/testing/mock/jcr/MockUserTest.java
@@ -24,11 +24,13 @@ import static org.junit.Assert.assertThrows;
 import static org.junit.Assert.assertTrue;
 
 import javax.jcr.Credentials;
+import javax.jcr.Node;
 import javax.jcr.RepositoryException;
 import javax.jcr.SimpleCredentials;
 import javax.jcr.UnsupportedRepositoryOperationException;
 
 import org.apache.jackrabbit.api.security.user.User;
+import org.apache.jackrabbit.oak.spi.security.user.UserConstants;
 import org.jetbrains.annotations.NotNull;
 import org.junit.Test;
 import org.mockito.Mockito;
@@ -186,6 +188,10 @@ public class MockUserTest extends MockAuthorizableTest<User> {
     @Override
     public void testGetPath() throws UnsupportedRepositoryOperationException, RepositoryException {
         assertEquals("/home/users/user1", authorizable.getPath());
+        assertTrue(session.nodeExists(authorizable.getPath()));
+        Node node = session.getNode(authorizable.getPath());
+        assertEquals(authorizable.getID(), 
+                node.getProperty(UserConstants.REP_PRINCIPAL_NAME).getString());
     }
 
 }


### PR DESCRIPTION
To support unit tests that interact with data stored in the user/group home folder, the MockUserManager should ensure that:

1. When creating a new user or group, ensure that the authorizable's path exists.
2. The MockUserManager needs to be aware of the items under the /home folder to discover users or groups that already exist.