### PR TITLE
SLING-12166 fix MockUserManager getAuthorizable(String, Class)

### DIFF
--- a/src/main/java/org/apache/sling/testing/mock/jcr/MockUserManager.java
+++ b/src/main/java/org/apache/sling/testing/mock/jcr/MockUserManager.java
@@ -333,10 +333,12 @@ public class MockUserManager implements UserManager {
             throws RepositoryException {
         T a = null;
         Authorizable authorizable = authorizables.get(id);
-        if (authorizableClass.isInstance(authorizable)) {
-            a = authorizableClass.cast(authorizable);
-        } else {
-            throw new AuthorizableTypeException("Not the expected authorizable class");
+        if (authorizable != null) { // SLING-12166
+            if (authorizableClass.isInstance(authorizable)) {
+                a = authorizableClass.cast(authorizable);
+            } else {
+                throw new AuthorizableTypeException("Not the expected authorizable class");
+            }
         }
         return a;
     }

--- a/src/test/java/org/apache/sling/testing/mock/jcr/MockUserManagerTest.java
+++ b/src/test/java/org/apache/sling/testing/mock/jcr/MockUserManagerTest.java
@@ -331,6 +331,14 @@ public class MockUserManagerTest {
 
         assertThrows(AuthorizableTypeException.class, () -> userManager.getAuthorizable("user1", Group.class));
     }
+    /**
+     * Test to verify the fix for SLING-12166
+     */
+    @Test
+    public void testGetAuthorizableStringClassOfTWhenItDoesNotExist() throws AuthorizableExistsException, RepositoryException {
+        @Nullable Authorizable authorizable = userManager.getAuthorizable("user1", User.class);
+        assertNull(authorizable);
+    }
 
     /**
      * Test method for {@link org.apache.sling.testing.mock.jcr.MockUserManager#getAuthorizableByPath(java.lang.String)}.


### PR DESCRIPTION
MockUserManager#getAuthorizable(String, Class) should return null if the user or group does not exist.  Currently it throws a AuthorizableTypeException instead.