### PR TITLE
SLING-12167 fix MockAuthorizable setProperty(String, Value[])

### DIFF
--- a/src/main/java/org/apache/sling/testing/mock/jcr/MockAuthorizable.java
+++ b/src/main/java/org/apache/sling/testing/mock/jcr/MockAuthorizable.java
@@ -164,8 +164,7 @@ abstract class MockAuthorizable implements Authorizable {
         return homeNode.hasProperty(relPath);
     }
 
-    @Override
-    public void setProperty(@NotNull String relPath, @Nullable Value value) throws RepositoryException {
+    protected Node createIntermediateNodes(@NotNull String relPath) throws RepositoryException {
         String[] segments = relPath.split("/");
         Node node = homeNode;
         for (int i = 0; i < segments.length - 1; i++) {
@@ -176,13 +175,21 @@ abstract class MockAuthorizable implements Authorizable {
                 node = node.addNode(segment, UserConstants.NT_REP_AUTHORIZABLE_FOLDER);
             }
         }
-        String propName = segments[segments.length - 1];
+        return node;
+    }
+
+    @Override
+    public void setProperty(@NotNull String relPath, @Nullable Value value) throws RepositoryException {
+        Node node = createIntermediateNodes(relPath);
+        String propName = ResourceUtil.getName(relPath);
         node.setProperty(propName, value);
     }
 
     @Override
     public void setProperty(@NotNull String relPath, @Nullable Value[] value) throws RepositoryException {
-        homeNode.setProperty(relPath, value);
+        Node node = createIntermediateNodes(relPath);
+        String propName = ResourceUtil.getName(relPath);
+        node.setProperty(propName, value);
     }
 
     @Override

--- a/src/test/java/org/apache/sling/testing/mock/jcr/MockAuthorizableTest.java
+++ b/src/test/java/org/apache/sling/testing/mock/jcr/MockAuthorizableTest.java
@@ -220,6 +220,24 @@ public abstract class MockAuthorizableTest<T extends Authorizable> {
         assertEquals(2, property.length);
         assertEquals("value1", property[0].getString());
         assertEquals("value2", property[1].getString());
+
+        // nested prop
+        authorizable.setProperty("relPath2/prop2", new Value [] {
+                vf.createValue("value2"),
+                vf.createValue("value3") });
+        property = authorizable.getProperty("relPath2/prop2");
+        assertNotNull(property);
+        assertEquals(2, property.length);
+        assertEquals("value2", property[0].getString());
+
+        // second nested prop where intermediate subnode already exists
+        authorizable.setProperty("relPath2/prop3", new Value [] {
+                vf.createValue("value3"),
+                vf.createValue("value4")});
+        property = authorizable.getProperty("relPath2/prop3");
+        assertNotNull(property);
+        assertEquals(2, property.length);
+        assertEquals("value3", property[0].getString());
     }
 
     /**


### PR DESCRIPTION
If the relPath argument contains multiple segments, then any missing intermediate nodes should be autocreated