### PR TITLE
SLING-12190 provide more real MockUser password handling

### DIFF
--- a/src/main/java/org/apache/sling/testing/mock/jcr/MockUser.java
+++ b/src/main/java/org/apache/sling/testing/mock/jcr/MockUser.java
@@ -29,6 +29,7 @@ import org.apache.jackrabbit.api.security.user.Impersonation;
 import org.apache.jackrabbit.api.security.user.User;
 import org.apache.jackrabbit.oak.spi.security.principal.SystemUserPrincipal;
 import org.apache.jackrabbit.oak.spi.security.user.UserConstants;
+import org.apache.jackrabbit.oak.spi.security.user.UserIdCredentials;
 import org.apache.jackrabbit.oak.spi.security.user.util.PasswordUtil;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
@@ -77,7 +78,13 @@ class MockUser extends MockAuthorizable implements User {
             pwd = null;
         }
 
-        return new SimpleCredentials(id, pwd);
+        Credentials creds;
+        if (pwd == null) {
+            creds = new UserIdCredentials(id);
+        } else {
+            creds = new SimpleCredentials(id, pwd);
+        }
+        return creds;
     }
 
     @Override

--- a/src/main/java/org/apache/sling/testing/mock/jcr/MockUserManager.java
+++ b/src/main/java/org/apache/sling/testing/mock/jcr/MockUserManager.java
@@ -82,7 +82,13 @@ public class MockUserManager implements UserManager {
                     protected void entering(Node node, int level) throws RepositoryException {
                         if (node.isNodeType(UserConstants.NT_REP_USER)) {
                             String userID = node.getProperty(UserConstants.REP_AUTHORIZABLE_ID).getString();
-                            authorizables.computeIfAbsent(userID, id -> new MockUser(id, null, node, MockUserManager.this));
+                            String pwd;
+                            if (node.hasProperty(UserConstants.REP_PASSWORD)) {
+                                pwd = node.getProperty(UserConstants.REP_PASSWORD).getString();
+                            } else {
+                                pwd = null;
+                            }
+                            authorizables.computeIfAbsent(userID, id -> new MockUser(id, null, pwd, node, MockUserManager.this));
                         } else if (node.isNodeType(UserConstants.NT_REP_SYSTEM_USER)) {
                             String userID = node.getProperty(UserConstants.REP_AUTHORIZABLE_ID).getString();
                             SystemUserPrincipal p = () -> userID;
@@ -306,7 +312,7 @@ public class MockUserManager implements UserManager {
             }
         }
         Node node = ensureAuthorizablePathExists(intermediatePath, principalName, authorizableNodeType);
-        return (User)authorizables.computeIfAbsent(userID, id -> new MockUser(id, principal, node, this));
+        return (User)authorizables.computeIfAbsent(userID, id -> new MockUser(id, principal, password, node, this));
     }
 
     @Override

--- a/src/main/java/org/apache/sling/testing/mock/jcr/MockUserManager.java
+++ b/src/main/java/org/apache/sling/testing/mock/jcr/MockUserManager.java
@@ -82,13 +82,7 @@ public class MockUserManager implements UserManager {
                     protected void entering(Node node, int level) throws RepositoryException {
                         if (node.isNodeType(UserConstants.NT_REP_USER)) {
                             String userID = node.getProperty(UserConstants.REP_AUTHORIZABLE_ID).getString();
-                            String pwd;
-                            if (node.hasProperty(UserConstants.REP_PASSWORD)) {
-                                pwd = node.getProperty(UserConstants.REP_PASSWORD).getString();
-                            } else {
-                                pwd = null;
-                            }
-                            authorizables.computeIfAbsent(userID, id -> new MockUser(id, null, pwd, node, MockUserManager.this));
+                            authorizables.computeIfAbsent(userID, id -> new MockUser(id, null, node, MockUserManager.this));
                         } else if (node.isNodeType(UserConstants.NT_REP_SYSTEM_USER)) {
                             String userID = node.getProperty(UserConstants.REP_AUTHORIZABLE_ID).getString();
                             SystemUserPrincipal p = () -> userID;
@@ -312,7 +306,11 @@ public class MockUserManager implements UserManager {
             }
         }
         Node node = ensureAuthorizablePathExists(intermediatePath, principalName, authorizableNodeType);
-        return (User)authorizables.computeIfAbsent(userID, id -> new MockUser(id, principal, password, node, this));
+        User user = (User)authorizables.computeIfAbsent(userID, id -> new MockUser(id, principal, node, this));
+        if (password != null) {
+            user.changePassword(password);
+        }
+        return user;
     }
 
     @Override

--- a/src/test/java/org/apache/sling/testing/mock/jcr/MockUserManagerTest.java
+++ b/src/test/java/org/apache/sling/testing/mock/jcr/MockUserManagerTest.java
@@ -31,6 +31,7 @@ import java.util.Set;
 import javax.jcr.Node;
 import javax.jcr.RepositoryException;
 import javax.jcr.Session;
+import javax.jcr.SimpleCredentials;
 import javax.jcr.UnsupportedRepositoryOperationException;
 import javax.jcr.ValueFactory;
 
@@ -115,7 +116,11 @@ public class MockUserManagerTest {
 
         userManager.loadAlreadyExistingAuthorizables();
 
-        assertNotNull(userManager.getAuthorizable("testuser1"));
+        @Nullable Authorizable authorizable = userManager.getAuthorizable("testuser1");
+        assertTrue(authorizable instanceof User);
+        // verify password state was stored
+        SimpleCredentials creds = (SimpleCredentials)((User)authorizable).getCredentials();
+        assertTrue(PasswordUtil.isSame(String.valueOf(creds.getPassword()), "testPwd"));
         assertNotNull(userManager.getAuthorizable("testuser2"));
         assertNotNull(userManager.getAuthorizable("testsystemuser1"));
         assertNotNull(userManager.getAuthorizable("testgroup1"));

--- a/src/test/java/org/apache/sling/testing/mock/jcr/MockUserManagerTest.java
+++ b/src/test/java/org/apache/sling/testing/mock/jcr/MockUserManagerTest.java
@@ -23,6 +23,8 @@ import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertThrows;
 import static org.junit.Assert.assertTrue;
 
+import java.io.UnsupportedEncodingException;
+import java.security.NoSuchAlgorithmException;
 import java.util.Iterator;
 import java.util.Set;
 
@@ -40,6 +42,7 @@ import org.apache.jackrabbit.api.security.user.Query;
 import org.apache.jackrabbit.api.security.user.User;
 import org.apache.jackrabbit.api.security.user.UserManager;
 import org.apache.jackrabbit.oak.spi.security.user.UserConstants;
+import org.apache.jackrabbit.oak.spi.security.user.util.PasswordUtil;
 import org.apache.jackrabbit.value.ValueFactoryImpl;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
@@ -87,13 +90,19 @@ public class MockUserManagerTest {
     }
 
     @Test
-    public void testLoadAlreadyExistingAuthorizables() throws RepositoryException {
+    public void testLoadAlreadyExistingAuthorizables() throws RepositoryException, NoSuchAlgorithmException, UnsupportedEncodingException {
         Node homeNode = session.getRootNode()
             .addNode("home", UserConstants.NT_REP_AUTHORIZABLE_FOLDER);
         Node usersNode = homeNode.addNode("users", UserConstants.NT_REP_AUTHORIZABLE_FOLDER);
         Node testuser1 = usersNode.addNode("testuser1", UserConstants.NT_REP_USER);
         testuser1.setProperty(UserConstants.REP_AUTHORIZABLE_ID, "testuser1");
         testuser1.setProperty(UserConstants.REP_PRINCIPAL_NAME, "testuser1");
+        testuser1.setProperty(UserConstants.REP_PASSWORD, PasswordUtil.buildPasswordHash("testPwd"));
+
+        // user with no password set - for code coverage
+        Node testuser2 = usersNode.addNode("testuser2", UserConstants.NT_REP_USER);
+        testuser2.setProperty(UserConstants.REP_AUTHORIZABLE_ID, "testuser2");
+        testuser2.setProperty(UserConstants.REP_PRINCIPAL_NAME, "testuser2");
 
         Node testsystemuser1 = usersNode.addNode("testsystemuser1", UserConstants.NT_REP_SYSTEM_USER);
         testsystemuser1.setProperty(UserConstants.REP_AUTHORIZABLE_ID, "testsystemuser1");
@@ -107,6 +116,7 @@ public class MockUserManagerTest {
         userManager.loadAlreadyExistingAuthorizables();
 
         assertNotNull(userManager.getAuthorizable("testuser1"));
+        assertNotNull(userManager.getAuthorizable("testuser2"));
         assertNotNull(userManager.getAuthorizable("testsystemuser1"));
         assertNotNull(userManager.getAuthorizable("testgroup1"));
     }

--- a/src/test/java/org/apache/sling/testing/mock/jcr/MockUserTest.java
+++ b/src/test/java/org/apache/sling/testing/mock/jcr/MockUserTest.java
@@ -154,6 +154,12 @@ public class MockUserTest extends MockAuthorizableTest<User> {
 
         assertThrows(RepositoryException.class, () -> authorizable.changePassword(null));
     }
+    @Test
+    public void testChangePasswordStringFromNull() throws RepositoryException {
+        // start with a null password - for code coverage
+        authorizable = userManager.createUser("testuser2", null);
+        assertThrows(RepositoryException.class, () -> authorizable.changePassword("changed", "oldPwd"));
+    }
 
     @Test
     public void testChangePasswordStringWithCaughtNoSuchAlgorithmException() throws RepositoryException {

--- a/src/test/java/org/apache/sling/testing/mock/jcr/MockUserTest.java
+++ b/src/test/java/org/apache/sling/testing/mock/jcr/MockUserTest.java
@@ -16,7 +16,6 @@
  */
 package org.apache.sling.testing.mock.jcr;
 
-import static org.junit.Assert.assertArrayEquals;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNull;
@@ -31,6 +30,7 @@ import javax.jcr.UnsupportedRepositoryOperationException;
 
 import org.apache.jackrabbit.api.security.user.User;
 import org.apache.jackrabbit.oak.spi.security.user.UserConstants;
+import org.apache.jackrabbit.oak.spi.security.user.util.PasswordUtil;
 import org.jetbrains.annotations.NotNull;
 import org.junit.Test;
 import org.mockito.Mockito;
@@ -136,7 +136,7 @@ public class MockUserTest extends MockAuthorizableTest<User> {
 
     protected void assertPassword(char [] expectedPwd) throws RepositoryException {
         SimpleCredentials creds = (SimpleCredentials)authorizable.getCredentials();
-        assertArrayEquals(expectedPwd, creds.getPassword());
+        assertTrue(PasswordUtil.isSame(new String(creds.getPassword()), expectedPwd));
     }
 
     /**
@@ -144,7 +144,7 @@ public class MockUserTest extends MockAuthorizableTest<User> {
      */
     @Test
     public void testChangePasswordStringString() throws RepositoryException {
-        authorizable.changePassword("changed", "");
+        authorizable.changePassword("changed", "pwd");
         assertPassword("changed".toCharArray());
 
         assertThrows(RepositoryException.class, () -> authorizable.changePassword("changed2", "wrong"));

--- a/src/test/java/org/apache/sling/testing/mock/jcr/MockUserTest.java
+++ b/src/test/java/org/apache/sling/testing/mock/jcr/MockUserTest.java
@@ -33,6 +33,7 @@ import javax.jcr.UnsupportedRepositoryOperationException;
 
 import org.apache.jackrabbit.api.security.user.User;
 import org.apache.jackrabbit.oak.spi.security.user.UserConstants;
+import org.apache.jackrabbit.oak.spi.security.user.UserIdCredentials;
 import org.apache.jackrabbit.oak.spi.security.user.util.PasswordUtil;
 import org.jetbrains.annotations.NotNull;
 import org.junit.Test;
@@ -117,6 +118,15 @@ public class MockUserTest extends MockAuthorizableTest<User> {
         @NotNull Credentials credentials = authorizable.getCredentials();
         assertTrue(credentials instanceof SimpleCredentials);
         assertEquals(authorizable.getID(), ((SimpleCredentials)credentials).getUserID());
+    }
+    @Test
+    public void testGetCredentialsWithNullPassword() throws RepositoryException {
+        // create a user with no password
+        authorizable = userManager.createUser("user2", null);
+
+        @NotNull Credentials credentials = authorizable.getCredentials();
+        assertTrue(credentials instanceof UserIdCredentials);
+        assertEquals(authorizable.getID(), ((UserIdCredentials)credentials).getUserId());
     }
 
     /**

--- a/src/test/java/org/apache/sling/testing/mock/jcr/MockUserTest.java
+++ b/src/test/java/org/apache/sling/testing/mock/jcr/MockUserTest.java
@@ -52,23 +52,6 @@ public class MockUserTest extends MockAuthorizableTest<User> {
     }
 
     @Test
-    public void testMockUserConstructorWithCaughtNoSuchAlgorithmException() {
-        try (MockedStatic<PasswordUtil> passwordUtilMock = Mockito.mockStatic(PasswordUtil.class);) {
-            passwordUtilMock.when(() -> PasswordUtil.buildPasswordHash("pwd"))
-                .thenThrow(NoSuchAlgorithmException.class);
-            assertThrows(IllegalArgumentException.class, () -> new MockUser("user1", null, "pwd", null, (MockUserManager)userManager));
-        }
-    }
-    @Test
-    public void testMockUserConstructorWithCaughtUnsupportedEncodingExceptionException() {
-        try (MockedStatic<PasswordUtil> passwordUtilMock = Mockito.mockStatic(PasswordUtil.class);) {
-            passwordUtilMock.when(() -> PasswordUtil.buildPasswordHash("pwd"))
-                .thenThrow(UnsupportedEncodingException.class);
-            assertThrows(IllegalArgumentException.class, () -> new MockUser("user1", null, "pwd", null, (MockUserManager)userManager));
-        }
-    }
-
-    @Test
     @Override
     public void testGetID() throws RepositoryException {
         assertEquals("user1", authorizable.getID());
@@ -236,6 +219,14 @@ public class MockUserTest extends MockAuthorizableTest<User> {
         Node node = session.getNode(authorizable.getPath());
         assertEquals(authorizable.getID(), 
                 node.getProperty(UserConstants.REP_PRINCIPAL_NAME).getString());
+    }
+
+    @Test
+    @Override
+    public void testGetPropertyNames() throws RepositoryException {
+        // create a user with no password so there are no initial properties
+        authorizable = userManager.createUser("user2", null);
+        super.testGetPropertyNames();
     }
 
 }


### PR DESCRIPTION
When creating a new user via the MockUserManager, the supplied user password was being ignored.

To allow more real testing around the changing the password, the MockUser password handling should be more real.