### PR TITLE
SLING-12195 MockUser use a home node property for the disabled state

### DIFF
--- a/src/main/java/org/apache/sling/testing/mock/jcr/MockUser.java
+++ b/src/main/java/org/apache/sling/testing/mock/jcr/MockUser.java
@@ -41,8 +41,6 @@ import org.slf4j.LoggerFactory;
  */
 class MockUser extends MockAuthorizable implements User {
     private Logger logger = LoggerFactory.getLogger(getClass());
-    private boolean disabled;
-    private String disabledReason;
 
     public MockUser(@Nullable String id, @Nullable Principal principal,
             @NotNull Node homeNode,
@@ -124,21 +122,25 @@ class MockUser extends MockAuthorizable implements User {
     @Override
     public void disable(@Nullable String reason) throws RepositoryException {
         if (reason == null) {
-            this.disabled = false;
-            this.disabledReason = null;
+            if (homeNode.hasProperty(UserConstants.REP_DISABLED)) {
+                homeNode.getProperty(UserConstants.REP_DISABLED).remove();
+            }
         } else {
-            this.disabled = true;
-            this.disabledReason = reason;
+            homeNode.setProperty(UserConstants.REP_DISABLED, reason);
         }
     }
 
     @Override
     public boolean isDisabled() throws RepositoryException {
-        return disabled;
+        return homeNode.hasProperty(UserConstants.REP_DISABLED);
     }
 
     @Override
     public @Nullable String getDisabledReason() throws RepositoryException {
+        String disabledReason = null;
+        if (homeNode.hasProperty(UserConstants.REP_DISABLED)) {
+            disabledReason = homeNode.getProperty(UserConstants.REP_DISABLED).getString();
+        }
         return disabledReason;
     }
 

--- a/src/test/java/org/apache/sling/testing/mock/jcr/MockUserManagerTest.java
+++ b/src/test/java/org/apache/sling/testing/mock/jcr/MockUserManagerTest.java
@@ -104,6 +104,8 @@ public class MockUserManagerTest {
         Node testuser2 = usersNode.addNode("testuser2", UserConstants.NT_REP_USER);
         testuser2.setProperty(UserConstants.REP_AUTHORIZABLE_ID, "testuser2");
         testuser2.setProperty(UserConstants.REP_PRINCIPAL_NAME, "testuser2");
+        // also disabled to verify this state is restored after loading
+        testuser2.setProperty(UserConstants.REP_DISABLED, "Bad Behavior");
 
         Node testsystemuser1 = usersNode.addNode("testsystemuser1", UserConstants.NT_REP_SYSTEM_USER);
         testsystemuser1.setProperty(UserConstants.REP_AUTHORIZABLE_ID, "testsystemuser1");
@@ -121,7 +123,11 @@ public class MockUserManagerTest {
         // verify password state was stored
         SimpleCredentials creds = (SimpleCredentials)((User)authorizable).getCredentials();
         assertTrue(PasswordUtil.isSame(String.valueOf(creds.getPassword()), "testPwd"));
-        assertNotNull(userManager.getAuthorizable("testuser2"));
+        @Nullable Authorizable authorizable2 = userManager.getAuthorizable("testuser2");
+        assertTrue(authorizable2 instanceof User);
+        // verify disabled state was stored
+        assertTrue(((User)authorizable2).isDisabled());
+        assertEquals("Bad Behavior", ((User)authorizable2).getDisabledReason());
         assertNotNull(userManager.getAuthorizable("testsystemuser1"));
         assertNotNull(userManager.getAuthorizable("testgroup1"));
     }

--- a/src/test/java/org/apache/sling/testing/mock/jcr/MockUserTest.java
+++ b/src/test/java/org/apache/sling/testing/mock/jcr/MockUserTest.java
@@ -199,6 +199,11 @@ public class MockUserTest extends MockAuthorizableTest<User> {
         authorizable.disable(null);
         assertFalse(authorizable.isDisabled());
         assertNull(authorizable.getDisabledReason());
+
+        // one more time for code coverage of user not previously disabled
+        authorizable.disable(null);
+        assertFalse(authorizable.isDisabled());
+        assertNull(authorizable.getDisabledReason());
     }
 
     /**


### PR DESCRIPTION
Instead of managing the disabled state as a field of MockUser, it should be stored as a property on the user's home node.

This ensures that the disabled state remains available when a new ResourceResolver is created via ResourceResolverFactory#getServiceResourceResolver