### PR TITLE
SLING-12992 treat create user/group intermediatePath as relative

### DIFF
--- a/src/test/java/org/apache/sling/testing/mock/jcr/MockUserManagerTest.java
+++ b/src/test/java/org/apache/sling/testing/mock/jcr/MockUserManagerTest.java
@@ -249,7 +249,7 @@ public class MockUserManagerTest {
     }
 
     @Test
-    public void testCreateSystemUserWithInvalidIntermediatePath() throws RepositoryException {
+    public void testCreateSystemUserWithInvalidIntermediatePath() {
         assertThrows(ConstraintViolationException.class, () -> userManager.createSystemUser("systemuser1", "invalid"));
     }
 


### PR DESCRIPTION
The current MockUserManager implementation is interpreting the intermediatePath argument when creating a user or group as an absolute path. 

The real oak/jackrabbit implementation is interpreting that argument as a relative path that is appended to the configured usersPath or groupsPath location.

Expected: the MockUserManager should behave more like the real implementation.

Also, for MockUserManager#createSystemUser implementation, the intermediatePath  value should have additional validation to ensure the value starts with "system".

