### PR TITLE
SLING-13179 cleanup sonar warnings

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -44,8 +44,6 @@
     <properties>
         <project.build.outputTimestamp>2026-02-12T13:50:15Z</project.build.outputTimestamp>
         <sling.java.version>11</sling.java.version>
-        <oak.version>1.68.0</oak.version>
-        <jackrabbit.version>2.22.2</jackrabbit.version>
     </properties>
 
     <dependencies>
@@ -70,13 +68,11 @@
         <dependency>
             <groupId>org.apache.jackrabbit</groupId>
             <artifactId>jackrabbit-jcr-commons</artifactId>
-            <version>${jackrabbit.version}</version>
             <scope>compile</scope>
         </dependency>
         <dependency>
             <groupId>org.apache.jackrabbit</groupId>
             <artifactId>oak-jackrabbit-api</artifactId>
-            <version>${oak.version}</version>
             <scope>compile</scope>
         </dependency>
         <!-- Depend on oak-jcr to simplify Maven dependency management in downstream unit test contexts.

--- a/src/main/java/org/apache/sling/testing/mock/jcr/AbstractItem.java
+++ b/src/main/java/org/apache/sling/testing/mock/jcr/AbstractItem.java
@@ -27,6 +27,7 @@ import javax.jcr.Session;
 import java.util.Objects;
 
 import org.apache.commons.lang3.StringUtils;
+import org.apache.commons.lang3.Strings;
 
 /**
  * Mock {@link Item} implementation.
@@ -82,7 +83,7 @@ abstract class AbstractItem implements Item {
     protected String makeAbsolutePath(final String relativePath) throws RepositoryException {
         String absolutePath = relativePath;
         // ensure the path is absolute and normalized
-        if (!StringUtils.startsWith(absolutePath, "/")) {
+        if (!Strings.CS.startsWith(absolutePath, "/")) {
             absolutePath = getPath() + "/" + absolutePath; // NOPMD NOSONAR
         }
         return ResourceUtil.normalize(absolutePath);
@@ -99,7 +100,7 @@ abstract class AbstractItem implements Item {
 
     @Override
     public int getDepth() throws RepositoryException {
-        if (StringUtils.equals("/", getPath())) {
+        if (Strings.CS.equals("/", getPath())) {
             return 0;
         } else {
             return StringUtils.countMatches(getPath(), "/");

--- a/src/main/java/org/apache/sling/testing/mock/jcr/MockJcr.java
+++ b/src/main/java/org/apache/sling/testing/mock/jcr/MockJcr.java
@@ -33,7 +33,7 @@ import java.io.Reader;
 import java.util.List;
 import java.util.Objects;
 
-import org.apache.commons.lang3.StringUtils;
+import org.apache.commons.lang3.Strings;
 import org.apache.jackrabbit.commons.cnd.CompactNodeTypeDefReader;
 import org.apache.jackrabbit.commons.cnd.ParseException;
 import org.apache.sling.testing.mock.jcr.MockNodeTypeManager.ResolveMode;
@@ -206,8 +206,8 @@ public final class MockJcr {
             @NotNull final List<Node> resultList,
             boolean simulateUnknownSize) {
         addQueryResultHandler(queryManager, query -> {
-            if (StringUtils.equals(query.getStatement(), statement)
-                    && StringUtils.equals(query.getLanguage(), language)) {
+            if (Strings.CS.equals(query.getStatement(), statement)
+                    && Strings.CS.equals(query.getLanguage(), language)) {
                 MockQueryResult mockQueryResult = new MockQueryResult(resultList);
                 mockQueryResult.setSimulateUnknownSize(simulateUnknownSize);
                 return mockQueryResult;

--- a/src/main/java/org/apache/sling/testing/mock/jcr/MockNode.java
+++ b/src/main/java/org/apache/sling/testing/mock/jcr/MockNode.java
@@ -48,6 +48,7 @@ import java.util.regex.Pattern;
 import java.util.stream.Stream;
 
 import org.apache.commons.lang3.StringUtils;
+import org.apache.commons.lang3.Strings;
 import org.apache.jackrabbit.JcrConstants;
 import org.apache.jackrabbit.commons.ItemNameMatcher;
 import org.apache.jackrabbit.commons.iterator.NodeIteratorAdapter;
@@ -112,7 +113,7 @@ class MockNode extends AbstractItem implements Node {
         }
 
         // special handling for some node types
-        if (StringUtils.equals(primaryNodeTypeName, JcrConstants.NT_FILE)) {
+        if (Strings.CS.equals(primaryNodeTypeName, JcrConstants.NT_FILE)) {
             node.setProperty(JcrConstants.JCR_CREATED, Calendar.getInstance());
             node.setProperty(JCR_CREATEDBY, getMockedSession().getUserID());
         }

--- a/src/main/java/org/apache/sling/testing/mock/jcr/MockNodeType.java
+++ b/src/main/java/org/apache/sling/testing/mock/jcr/MockNodeType.java
@@ -35,7 +35,7 @@ import java.util.Map;
 import java.util.Set;
 import java.util.stream.Stream;
 
-import org.apache.commons.lang3.StringUtils;
+import org.apache.commons.lang3.Strings;
 import org.apache.jackrabbit.JcrConstants;
 import org.apache.jackrabbit.commons.iterator.NodeTypeIteratorAdapter;
 import org.apache.sling.testing.mock.jcr.MockNodeTypeManager.ResolveMode;
@@ -88,7 +88,7 @@ class MockNodeType implements NodeType {
             return ntd.hasOrderableChildNodes();
         }
         // support only well-known built-in node type
-        return StringUtils.equals(getName(), JcrConstants.NT_UNSTRUCTURED);
+        return Strings.CS.equals(getName(), JcrConstants.NT_UNSTRUCTURED);
     }
 
     // --- unsupported operations ---

--- a/src/main/java/org/apache/sling/testing/mock/jcr/MockQuery.java
+++ b/src/main/java/org/apache/sling/testing/mock/jcr/MockQuery.java
@@ -43,7 +43,7 @@ public final class MockQuery implements Query {
 
     private long limit;
     private long offset;
-    private Map<String, Value> variables = new HashMap<String, Value>();
+    private Map<String, Value> variables = new HashMap<>();
 
     MockQuery(MockQueryManager queryManager, String statement, String language) {
         this.queryManager = queryManager;

--- a/src/main/java/org/apache/sling/testing/mock/jcr/MockQueryManager.java
+++ b/src/main/java/org/apache/sling/testing/mock/jcr/MockQueryManager.java
@@ -39,7 +39,7 @@ import org.apache.commons.lang3.StringUtils;
  */
 class MockQueryManager implements QueryManager {
 
-    private List<MockQueryResultHandler> resultHandlers = new ArrayList<MockQueryResultHandler>();
+    private List<MockQueryResultHandler> resultHandlers = new ArrayList<>();
 
     @SuppressWarnings("deprecation")
     private static final List<String> SUPPORTED_QUERY_LANGUAGES =

--- a/src/main/java/org/apache/sling/testing/mock/jcr/MockRepository.java
+++ b/src/main/java/org/apache/sling/testing/mock/jcr/MockRepository.java
@@ -42,7 +42,7 @@ import org.apache.commons.lang3.ArrayUtils;
 class MockRepository implements Repository {
 
     // Use linked hashmap to ensure ordering when adding items is preserved.
-    private final Map<String, ItemData> items = new LinkedHashMap<String, ItemData>();
+    private final Map<String, ItemData> items = new LinkedHashMap<>();
 
     private final NamespaceRegistry namespaceRegistry = new MockNamespaceRegistry();
     private final ObservationManager observationManager = new MockObservationManager();

--- a/src/main/java/org/apache/sling/testing/mock/jcr/MockSession.java
+++ b/src/main/java/org/apache/sling/testing/mock/jcr/MockSession.java
@@ -44,7 +44,7 @@ import java.util.Map;
 import java.util.Map.Entry;
 import java.util.regex.Pattern;
 
-import org.apache.commons.lang3.StringUtils;
+import org.apache.commons.lang3.Strings;
 import org.apache.jackrabbit.api.JackrabbitSession;
 import org.apache.jackrabbit.api.security.principal.PrincipalManager;
 import org.apache.jackrabbit.api.security.user.UserManager;
@@ -127,7 +127,7 @@ class MockSession implements Session, JackrabbitSession {
     public Node getNodeByIdentifier(final String id) throws RepositoryException {
         checkLive();
         for (ItemData item : this.items.values()) {
-            if (item.isNode() && StringUtils.equals(item.getUuid(), id)) {
+            if (item.isNode() && Strings.CS.equals(item.getUuid(), id)) {
                 return new MockNode(item, this);
             }
         }

--- a/src/main/java/org/apache/sling/testing/mock/jcr/MockSession.java
+++ b/src/main/java/org/apache/sling/testing/mock/jcr/MockSession.java
@@ -200,7 +200,7 @@ class MockSession implements Session, JackrabbitSession {
         final ItemData parent = getItemData(absPath);
         final String descendantPrefix = parent.getPath() + "/";
 
-        final List<String> pathsToRemove = new ArrayList<String>();
+        final List<String> pathsToRemove = new ArrayList<>();
         pathsToRemove.add(parent.getPath());
         for (String itemPath : this.items.keySet()) {
             if (itemPath.startsWith(descendantPrefix)) {
@@ -215,7 +215,7 @@ class MockSession implements Session, JackrabbitSession {
     }
 
     RangeIterator listChildren(final String parentPath, final ItemFilter filter) throws RepositoryException {
-        List<Item> children = new ArrayList<Item>();
+        List<Item> children = new ArrayList<>();
 
         // remove trailing slash or make root path / empty string
         final String path = parentPath.replaceFirst("/$", "");

--- a/src/main/java/org/apache/sling/testing/mock/jcr/ResourceUtil.java
+++ b/src/main/java/org/apache/sling/testing/mock/jcr/ResourceUtil.java
@@ -32,7 +32,7 @@ class ResourceUtil {
     public static String normalize(String path) {
 
         // don't care for empty paths
-        if (path.length() == 0) {
+        if (path.isEmpty()) {
             return path;
         }
 

--- a/src/test/java/org/apache/sling/testing/mock/jcr/LogCapture.java
+++ b/src/test/java/org/apache/sling/testing/mock/jcr/LogCapture.java
@@ -42,7 +42,7 @@ public class LogCapture extends ListAppender<ILoggingEvent> implements AutoClose
     public LogCapture(String loggerName, boolean verboseFailure) {
         this.verboseFailure = verboseFailure;
         logger = (Logger) LoggerFactory.getLogger(loggerName);
-        logger.setLevel(Level.ALL);
+        logger.setLevel(Level.TRACE);
         setContext((LoggerContext) LoggerFactory.getILoggerFactory());
         logger.addAppender(this);
         start();

--- a/src/test/java/org/apache/sling/testing/mock/jcr/MockQueryManagerTest.java
+++ b/src/test/java/org/apache/sling/testing/mock/jcr/MockQueryManagerTest.java
@@ -30,7 +30,7 @@ import javax.jcr.query.Row;
 import java.util.List;
 
 import org.apache.commons.collections4.IteratorUtils;
-import org.apache.commons.lang3.StringUtils;
+import org.apache.commons.lang3.Strings;
 import org.junit.Before;
 import org.junit.Test;
 
@@ -169,7 +169,7 @@ public class MockQueryManagerTest {
         MockJcr.addQueryResultHandler(queryManager, new MockQueryResultHandler() {
             @Override
             public MockQueryResult executeQuery(MockQuery query) {
-                if (StringUtils.equals(query.getStatement(), "query1")) {
+                if (Strings.CS.equals(query.getStatement(), "query1")) {
                     return new MockQueryResult(sampleNodes);
                 }
                 return null;
@@ -185,7 +185,7 @@ public class MockQueryManagerTest {
         MockJcr.addQueryResultHandler(queryManager, new MockQueryResultHandler() {
             @Override
             public MockQueryResult executeQuery(MockQuery query) {
-                if (StringUtils.equals(query.getStatement(), "query1")) {
+                if (Strings.CS.equals(query.getStatement(), "query1")) {
                     MockQueryResult mockQueryResult = new MockQueryResult(sampleNodes);
                     mockQueryResult.setSimulateUnknownSize(true);
                     return mockQueryResult;
@@ -205,7 +205,7 @@ public class MockQueryManagerTest {
         MockJcr.addQueryResultHandler(session, new MockQueryResultHandler() {
             @Override
             public MockQueryResult executeQuery(MockQuery query) {
-                if (StringUtils.equals(query.getStatement(), "query2")) {
+                if (Strings.CS.equals(query.getStatement(), "query2")) {
                     return new MockQueryResult(sampleNodes2);
                 }
                 return null;
@@ -215,7 +215,7 @@ public class MockQueryManagerTest {
         MockJcr.addQueryResultHandler(session, new MockQueryResultHandler() {
             @Override
             public MockQueryResult executeQuery(MockQuery query) {
-                if (StringUtils.equals(query.getStatement(), "query1")) {
+                if (Strings.CS.equals(query.getStatement(), "query1")) {
                     return new MockQueryResult(sampleNodes);
                 }
                 return null;

--- a/src/test/java/org/apache/sling/testing/mock/jcr/MockUserManagerTest.java
+++ b/src/test/java/org/apache/sling/testing/mock/jcr/MockUserManagerTest.java
@@ -285,6 +285,7 @@ public class MockUserManagerTest {
     /**
      * Test method for {@link org.apache.sling.testing.mock.jcr.MockUserManager#ensureAuthorizablePathExists(java.lang.String, java.lang.String, boolean)}.
      */
+    @SuppressWarnings("removal")
     @Deprecated
     @Test
     public void testEnsureAuthorizablePathExistsStringStringBoolean() throws RepositoryException {


### PR DESCRIPTION
Resolve various warnings:

- remove overridden managed versions of dependencies in the pom
- refactor usage of deprecated apis